### PR TITLE
Fix exist_app, `app list` and `app set`

### DIFF
--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -8,8 +8,8 @@ export const checkAppExistsAndHasPermission = async (supabase: SupabaseClient<Da
   const { data: app, error: dbError0 } = await supabase
     .rpc('exist_app', { appid, apikey })
     .single();
-  if (app === shouldExist || dbError0) {
-    program.error(`No permission for this app ${appid}`);
+  if (app !== shouldExist || dbError0) {
+    program.error("No permission for this app");
   }
 }
 

--- a/src/app/list.ts
+++ b/src/app/list.ts
@@ -25,7 +25,7 @@ export const listApp = async (appId: string, options: OptionsBase) => {
   console.log(`Querying available versions in Capgo`);
 
   // Check we have app access to this appId
-  await checkAppExistsAndHasPermission(supabase, appId, options.apikey);
+  await checkAppExistsAndHasPermission(supabase, appId, apikey);
 
   // Get all active app versions we might possibly be able to cleanup
   const allVersions = await getActiveAppVersions(supabase, appId, userId);

--- a/src/app/set.ts
+++ b/src/app/set.ts
@@ -5,7 +5,7 @@ import { existsSync, readFileSync } from "fs-extra";
 import { checkAppExistsAndHasPermission, newIconPath, Options } from '../api/app';
 import { createSupabaseClient, findSavedKey, formatError, getConfig, verifyUser } from "../utils";
 
-export const setApp = async (appId: string, userId: string, options: Options) => {
+export const setApp = async (appId: string, options: Options) => {
     options.apikey = options.apikey || findSavedKey() || ''
     const config = await getConfig();
     appId = appId || config?.app?.appId
@@ -18,7 +18,7 @@ export const setApp = async (appId: string, userId: string, options: Options) =>
     }
     const supabase = createSupabaseClient(options.apikey)
 
-    await verifyUser(supabase, options.apikey, ['write', 'all']);
+    const userId = await verifyUser(supabase, options.apikey, ['write', 'all']);
     // Check we have app access to this appId
     await checkAppExistsAndHasPermission(supabase, appId, options.apikey);
 


### PR DESCRIPTION
The `exists_app` rpc call is failing because it's throwing an error if the expectation matches the return value. Seems like the logic here is reversed?

![image](https://user-images.githubusercontent.com/4867329/220193751-6d3e24f0-f93c-4f32-b508-9d835cb2a355.png)

`app list` is failing if you use a saved apikey instead of `--apikey`

`app set` is failing because it's expecting an explicit `userId` which isn't configured in the command instead of reading it from `verifyUser()`

I couldn't test these changes because I can't build this locally. but I used the node debugger to simulate these changes at runtime and the commands completed successfully - with one caveat `app set --icon ... --name` succeeds, but doesn't update the icon or app name

<img width="548" alt="CleanShot 2023-02-20 at 21 31 04@2x" src="https://user-images.githubusercontent.com/4867329/220193730-dafb556f-0af0-45c8-86bf-5bd6fc67c133.png">

