### PR TITLE
Implement #140 and #169

### DIFF
--- a/src/bundle/current.ts
+++ b/src/bundle/current.ts
@@ -69,4 +69,6 @@ export const currentBundle = async (channel: string, options: Options, appId: st
         p.log.info(`Current bundle for channel ${channel} is ${version.name}`)
     else
         console.log(version.name)
+
+    process.exit()
 }

--- a/src/bundle/current.ts
+++ b/src/bundle/current.ts
@@ -1,0 +1,72 @@
+import { program } from "commander";
+import * as p from '@clack/prompts';
+import { checkAppExistsAndHasPermissionErr } from "../api/app";
+import { OptionsBase } from "../api/utils";
+import { createSupabaseClient, findSavedKey, getConfig, verifyUser } from "../utils";
+
+
+interface Options extends OptionsBase {
+    channel?: string,
+    quiet?: boolean
+}
+
+interface Channel {
+    version: {
+        name: string;
+    }
+}
+
+export const currentBundle = async (channel: string, options: Options, appId: string) => {
+    const { quiet } = options
+
+    if (!quiet)
+        p.intro(`List current bundle`);
+
+
+    options.apikey = options.apikey || findSavedKey(quiet)
+    const config = await getConfig();
+    appId = config?.app?.appId
+  
+    if (!options.apikey) {
+      p.log.error("Missing API key, you need to provide a API key to upload your bundle");
+      program.error('');
+    }
+    if (!appId) {
+      p.log.error("Missing argument, you need to provide a appId, or be in a capacitor project");
+      program.error('');
+    }
+    const supabase = createSupabaseClient(options.apikey)
+  
+    const userId = await verifyUser(supabase, options.apikey, ['write', 'all', 'read']);
+    // Check we have app access to this appId
+    await checkAppExistsAndHasPermissionErr(supabase, appId);
+
+    if (!channel) {
+        p.log.error(`Please provide a channel to get the bundle from.`);
+        program.error('');
+    }
+
+    const { data: supabaseChannel, error } = await supabase
+        .from('channels')
+        .select('version ( name )') 
+        .eq('name', channel)
+        .eq('app_id', appId)
+        .eq('created_by', userId)
+        .limit(1)
+
+    if (error || supabaseChannel.length === 0) {
+        p.log.error(`Error retrieving channel ${channel} for app ${appId}. Perhaps the channel does not exists?`);
+        program.error('');
+    }
+
+    const { version } = supabaseChannel[0] as any as Channel
+    if (!version) {
+        p.log.error(`Error retrieving channel ${channel} for app ${appId}. Perhaps the channel does not exists?`);
+        program.error('');
+    }
+
+    if (!quiet)
+        p.log.info(`Current bundle for channel ${channel} is ${version.name}`)
+    else
+        console.log(version.name)
+}

--- a/src/channel/currentBundle.ts
+++ b/src/channel/currentBundle.ts
@@ -27,7 +27,6 @@ export const currentBundle = async (channel: string, appId: string, options: Opt
     const config = await getConfig();
     appId = appId || config?.app?.appId
   
-    console.log(appId, options.apikey)
     if (!options.apikey) {
       p.log.error("Missing API key, you need to provide a API key to upload your bundle");
       program.error('');

--- a/src/channel/currentBundle.ts
+++ b/src/channel/currentBundle.ts
@@ -16,7 +16,7 @@ interface Channel {
     }
 }
 
-export const currentBundle = async (channel: string, options: Options, appId: string) => {
+export const currentBundle = async (channel: string, appId: string, options: Options) => {
     const { quiet } = options
 
     if (!quiet)
@@ -25,8 +25,9 @@ export const currentBundle = async (channel: string, options: Options, appId: st
 
     options.apikey = options.apikey || findSavedKey(quiet)
     const config = await getConfig();
-    appId = config?.app?.appId
+    appId = appId || config?.app?.appId
   
+    console.log(appId, options.apikey)
     if (!options.apikey) {
       p.log.error("Missing API key, you need to provide a API key to upload your bundle");
       program.error('');

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { getInfo } from './app/info';
 import { saveKeyCommand, createKeyCommand } from './key';
 import { deleteBundle } from './bundle/delete';
 import { setChannel } from './channel/set';
+import { currentBundle } from './bundle/current';
 import { uploadCommand, uploadDeprecatedCommand } from './bundle/upload';
 import pack from '../package.json'
 import { loginCommand } from './login';
@@ -139,6 +140,14 @@ bundle
   .option('-a, --apikey <apikey>', 'apikey to link to your account');
 
 bundle
+    .command('current [channel]')
+    .description('Get current bundle for specific channel in Capgo Cloud')
+    .action(currentBundle)
+    .option('-c, --channel <channel>', 'channel to get the current bundle from')
+    .option('-a, --apikey <apikey>', 'apikey to link to your account')
+    .option('--quiet', 'only print the bundle version')
+
+bundle
   .command('unlink [appId]')
   .alias('u')
   .description('Unlink a bundle in Capgo Cloud')
@@ -221,7 +230,10 @@ channel
   .option('--android', 'Allow sending update to android devices')
   .option('--no-android', 'Disable sending update to android devices')
   .option('--self-assign', 'Allow to device to self assign to this channel')
-  .option('--no-self-assign', 'Disable devices to self assign to this channel');
+  .option('--no-self-assign', 'Disable devices to self assign to this channel')
+  .option('--disable-auto-update <disableAutoUpdate>', 
+    'Disable auto update strategy for this channel.The possible options are: major, minor, metadata, none'
+  )
 
 const key = program
   .command('key')

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { getInfo } from './app/info';
 import { saveKeyCommand, createKeyCommand } from './key';
 import { deleteBundle } from './bundle/delete';
 import { setChannel } from './channel/set';
-import { currentBundle } from './bundle/current';
+import { currentBundle } from './channel/currentBundle';
 import { uploadCommand, uploadDeprecatedCommand } from './bundle/upload';
 import pack from '../package.json'
 import { loginCommand } from './login';
@@ -140,14 +140,6 @@ bundle
   .option('-a, --apikey <apikey>', 'apikey to link to your account');
 
 bundle
-    .command('current [channel]')
-    .description('Get current bundle for specific channel in Capgo Cloud')
-    .action(currentBundle)
-    .option('-c, --channel <channel>', 'channel to get the current bundle from')
-    .option('-a, --apikey <apikey>', 'apikey to link to your account')
-    .option('--quiet', 'only print the bundle version')
-
-bundle
   .command('unlink [appId]')
   .alias('u')
   .description('Unlink a bundle in Capgo Cloud')
@@ -211,6 +203,14 @@ channel
   .alias('l')
   .description('List channel')
   .action(listChannels)
+
+channel
+  .command('currentBundle [channel] [appId]')
+  .description('Get current bundle for specific channel in Capgo Cloud')
+  .action(currentBundle)
+  .option('-c, --channel <channel>', 'channel to get the current bundle from')
+  .option('-a, --apikey <apikey>', 'apikey to link to your account')
+  .option('--quiet', 'only print the bundle version')
 
 channel
   .command('set [channelId] [appId]')

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -141,18 +141,20 @@ export const checkPlanValid = async (supabase: SupabaseClient<Database>, userId:
     }
 }
 
-export const findSavedKey = () => {
+export const findSavedKey = (quiet = false) => {
     // search for key in home dir
     const userHomeDir = homedir();
     let key
     let keyPath = `${userHomeDir}/.capgo`;
     if (existsSync(keyPath)) {
-        p.log.info(`Use global apy key ${keyPath}`)
+        if (!quiet)
+            p.log.info(`Use global apy key ${keyPath}`)
         key = readFileSync(keyPath, 'utf8').trim();
     }
     keyPath = `.capgo`;
     if (!key && existsSync(keyPath)) {
-        p.log.info(`Use local apy key ${keyPath}`)
+        if (!quiet)
+            p.log.info(`Use local apy key ${keyPath}`)
         key = readFileSync(keyPath, 'utf8').trim();
     }
     if (!key)


### PR DESCRIPTION
The new commands are:

```bash
node ~/dev/CLI/dist/index.js bundle current production --quiet
node ~/dev/CLI/dist/index.js bundle current production
node ~/dev/CLI/dist/index.js channel set production --disable-auto-update major
```

As for tests: If needed I can implement them later. @riderx let me know if you  want tests for this.
Also my changes do not break any existing command. I checked, they are backward compatible

Here is a showcase of my changes:
![image](https://github.com/Cap-go/CLI/assets/50914789/24bf04a2-4538-4bc5-9271-d7101941c4ec)
![image](https://github.com/Cap-go/CLI/assets/50914789/c8ad66d2-2926-4e7e-9a55-786ed3ed61dd)
![image](https://github.com/Cap-go/CLI/assets/50914789/68a04d83-4952-4fb5-b4b4-80461cd647e6)

/claim #140
/claim #169