### PR TITLE
Detect native packages

### DIFF
--- a/src/bundle/compatibility.ts
+++ b/src/bundle/compatibility.ts
@@ -32,7 +32,7 @@ export const checkCompatibilityCommand = async (appId: string, options: Options)
         program.error('');
     }
     
-    const supabase = createSupabaseClient(options.apikey)
+    const supabase = await createSupabaseClient(options.apikey)
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const _ = await verifyUser(supabase, options.apikey, ['write', 'all', 'read', 'upload']);
 

--- a/src/bundle/compatibility.ts
+++ b/src/bundle/compatibility.ts
@@ -1,0 +1,69 @@
+import * as p from '@clack/prompts';
+import { program } from 'commander';
+import { Table } from 'console-table-printer';
+import { OptionsBase } from "../api/utils"
+import { createSupabaseClient, findSavedKey, getConfig, verifyUser, checkCompatibility } from '../utils';
+import { checkAppExistsAndHasPermissionErr } from '../api/app';
+
+interface Options extends OptionsBase {
+    channel?: string
+}
+
+export const checkCompatibilityCommand = async (appId: string, options: Options) => {
+    p.intro(`Check compatibility`);
+    options.apikey = options.apikey || findSavedKey()
+    const config = await getConfig();
+    appId = appId || config?.app?.appId
+
+    const { channel } = options;
+
+ 
+    if (!channel) {
+        p.log.error("Missing argument, you need to provide a channel");
+        program.error('');
+    }
+
+    if (!options.apikey) {
+        p.log.error("Missing API key, you need to provide a API key to upload your bundle");
+        program.error('');
+    }
+    if (!appId) {
+        p.log.error("Missing argument, you need to provide a appId, or be in a capacitor project");
+        program.error('');
+    }
+    
+    const supabase = createSupabaseClient(options.apikey)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const _ = await verifyUser(supabase, options.apikey, ['write', 'all', 'read', 'upload']);
+
+    // Check we have app access to this appId
+    await checkAppExistsAndHasPermissionErr(supabase, appId);
+
+    // const hashedLocalDependencies = new Map(dependenciesObject
+    //     .filter((a) => !!a.native && a.native !== undefined)
+    //     .map((a) => [a.name, a]))
+
+    // const nativePackages = Array.from(hashedLocalDependencies, ([name, value]) => ({ name, version: value.version }))
+    // await supabase.from('app_versions').update({ native_packages: nativePackages }).eq('id', '9654')
+
+    const { finalCompatibility } = await checkCompatibility(supabase, channel)
+
+
+    const t = new Table({
+        title: "Compatibility",
+        charLength: { "❌": 2, "✅": 2 },
+    });
+    
+    finalCompatibility.forEach((data) => {
+        const { name, localVersion, remoteVersion } = data
+
+        t.addRow({
+            Package: name,
+            'Local version': localVersion,
+            'Remote version': remoteVersion ?? 'None',
+            Compatible: remoteVersion === localVersion ? '✅' : '❌',
+        });
+    })
+    
+    p.log.success(t.render());
+}

--- a/src/bundle/compatibility.ts
+++ b/src/bundle/compatibility.ts
@@ -59,7 +59,7 @@ export const checkCompatibilityCommand = async (appId: string, options: Options)
 
         t.addRow({
             Package: name,
-            'Local version': localVersion,
+            'Local version': localVersion ?? 'None',
             'Remote version': remoteVersion ?? 'None',
             Compatible: remoteVersion === localVersion ? '✅' : '❌',
         });

--- a/src/bundle/upload.ts
+++ b/src/bundle/upload.ts
@@ -134,7 +134,7 @@ export const uploadBundle = async (appid: string, options: Options, shouldExit =
       try {
         const { minUpdateVersion: lastMinUpdateVersion } = channelData.version as any
         if (!lastMinUpdateVersion || !regexSemver.test(lastMinUpdateVersion)) {
-          p.log.error('Invalid min update version, skipping auto setting compatibility');
+          p.log.error('Invalid remote min update version, skipping auto setting compatibility');
           program.error('');
         }
   

--- a/src/bundle/upload.ts
+++ b/src/bundle/upload.ts
@@ -104,7 +104,7 @@ export const uploadBundle = async (appid: string, options: Options, shouldExit =
   // Check compatibility here
   const { data: channelData, error: channelError } = await supabase
   .from('channels')
-  .select('version ( minUpdateVersion )')
+  .select('version ( minUpdateVersion, native_packages )')
   .eq('name', channel)
   .eq('app_id', appid)
   .single()
@@ -113,7 +113,7 @@ export const uploadBundle = async (appid: string, options: Options, shouldExit =
   let finalCompatibility: Awaited<ReturnType<typeof checkCompatibility>>['finalCompatibility'];
 
   // We only check compatibility IF the channel exists
-  if (!channelError && channelData) {
+  if (!channelError && channelData && channelData.version && (channelData.version as any).native_packages) {
     const { 
       finalCompatibility: finalCompatibilityWithChannel,
       localDependencies: localDependenciesWithChannel 
@@ -146,7 +146,7 @@ export const uploadBundle = async (appid: string, options: Options, shouldExit =
       }
     }
   } else {
-    p.log.warn(`Channel ${channel} does not exist, cannot check compatibility`);
+    p.log.warn(`Channel ${channel} does not exist or previous metadata does not exist, cannot check compatibility`);
     localDependencies = await getLocalDepenencies()
 
     if (autoMinUpdateVersion) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { setApp } from './app/set';
 import { deleteApp } from './app/delete';
 // import { watchApp } from './app/watch';
 import { debugApp } from './app/debug';
+import { checkCompatibilityCommand } from './bundle/compatibility';
 
 program
   .name(pack.name)
@@ -124,6 +125,13 @@ bundle
     '--min-update-version <minUpdateVersion>',
     'Minimal version required to update to this version. Used only if the disable auto update is set to metadata in channel'
   )
+  .option('--auto-min-update-version', 'Set the min update version based on native packages')
+
+bundle
+    .command('compatibility [appId]')
+    .action(checkCompatibilityCommand)
+    .option('-a, --apikey <apikey>', 'apikey to link to your account')
+    .option('-c, --channel <channel>', 'channel to check the compatibility with')
 
 bundle
   .command('delete [bundleId] [appId]')

--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -182,6 +182,7 @@ export interface Database {
           id: number
           minUpdateVersion: string | null
           name: string
+          native_packages: Json[] | null
           session_key: string | null
           storage_provider: string
           updated_at: string | null
@@ -197,6 +198,7 @@ export interface Database {
           id?: number
           minUpdateVersion?: string | null
           name: string
+          native_packages?: Json[] | null
           session_key?: string | null
           storage_provider?: string
           updated_at?: string | null
@@ -212,6 +214,7 @@ export interface Database {
           id?: number
           minUpdateVersion?: string | null
           name?: string
+          native_packages?: Json[] | null
           session_key?: string | null
           storage_provider?: string
           updated_at?: string | null

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,6 +50,9 @@ export const getLocalConfig = async () => {
     }
 
 }
+
+const nativeFileRegex = /([A-Za-z0-9]+)\.(java|swift|kt|scala)$/
+
 interface CapgoConfig {
     supaHost: string
     supaKey: string

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -464,6 +464,11 @@ export async function getRemoteDepenencies(supabase: SupabaseClient<Database>, c
         program.error('');
     }
 
+    if (!castedRemoteNativePackages) {
+        p.log.error(`Error parsing native packages, perhaps the metadata does not exist?`);
+        program.error('');
+    }
+
     // Check types
     castedRemoteNativePackages.forEach((data: any) => {
         if (typeof data !== 'object') {


### PR DESCRIPTION
This PR adds the following things:

 * `bundle compatibility` command to check if the bundle that we are trying to upload is compatible with the latest channel.
 * A `--auto-min-update-version` option to automatically set the `minUpdateVersion` used when the disallow update strategy is enabled.
 
 Here is a more detailed explanation and a showcase:
 
 First the compatibility table:
  
![image](https://github.com/Cap-go/CLI/assets/50914789/5eafb210-7874-4154-afe5-eec234b7a678)

This handles well all edge cases:
When there is a dependency in the remote version but not locally (Dependency has been removed):
![image](https://github.com/Cap-go/CLI/assets/50914789/3f1ebbd0-239a-478a-a757-829009aa6866)

When the version has changed locally (update)
![image](https://github.com/Cap-go/CLI/assets/50914789/b7b8e8d8-9599-429b-908c-7c0438ed38f9)
 
When the version has changed locally (downgrade from remote)
![image](https://github.com/Cap-go/CLI/assets/50914789/34eb1abe-7483-4232-8dc0-f54a717a886c)

When a new dependency has been added:
![image](https://github.com/Cap-go/CLI/assets/50914789/3fa22d84-ff82-44cb-a7a2-e063e60c2151)

Next this adds the `--auto-min-update-version` to the upload command. Here is how it looks:
![image](https://github.com/Cap-go/CLI/assets/50914789/8f1048c3-0082-4e88-a988-45db00efdc39)

(This flag is useful only when the `metadata` strategy is used for disabling updates)

The important thing is that there was some manifest in supabase, however the CLI deemed the remote version to not be compatible with the remote currently uploaded version.

Since the new version is not compatible a app store update is required. Thus the min version is the `1.0.31`.

Now, let's upload a new version. This time we will not change any native dependency
![image](https://github.com/Cap-go/CLI/assets/50914789/978c8796-8498-4e84-a292-067e8f0d9bab)

Well the latest version uploaded to capgo was deemed to be compatible with this new version. Thus an update is possible and the min update version is also `1.0.31`

However sometimes you will not have a previous min update version available. (For example because you have just enabled the metadata disallow strategy). In that case you probably want to manually configure it instead of it having it auto generated

![image](https://github.com/Cap-go/CLI/assets/50914789/ebf857c6-7543-421c-8a5f-50c8c08a4d1a)

This change is not breaking. If there is no metadata the CLI will fail nicely
![image](https://github.com/Cap-go/CLI/assets/50914789/deaf38f6-0ada-448d-9eb6-0cc8fa605ca2)

As for the upload flag. If there is no metadata the update is assumed to be breaking thus we set the min update version to bundle number

![image](https://github.com/Cap-go/CLI/assets/50914789/59c963b5-9a4e-41f9-b7aa-eaa046839d04)

Schema change: https://github.com/Cap-go/capgo/pull/419
/claim #87