### PR TITLE
is_app_owner -> is_allowed_action

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -144,7 +144,7 @@ export const isAllowedAction = async (supabase: SupabaseClient<Database>, userId
 
 export const isAllowedApp = async (supabase: SupabaseClient<Database>, apikey: string, appId: string): Promise<boolean> => {
     const { data } = await supabase
-        .rpc('is_app_owner', { apikey, appid: appId })
+        .rpc('is_allowed_action', { apikey, appid: appId })
         .single()
     return !!data
 }


### PR DESCRIPTION
The `is_app_owner` fn is defined as

```sql
CREATE OR REPLACE FUNCTION "public"."is_app_owner"("userid" "uuid", "appid" character varying) RETURNS boolean
    LANGUAGE "plpgsql" SECURITY DEFINER
    AS $$
Begin
  RETURN (SELECT EXISTS (SELECT 1
  FROM apps
  WHERE app_id=appid
  AND user_id=userid));
End;  
$$;
```

But the CLI calls it as `is_app_owner(apikey, appid)`
This causes the following postgress error
![image](https://github.com/Cap-go/CLI/assets/50914789/367a6028-3024-47a1-942c-6bcdc6b66461)


By migrating to `is_allowed_action` everything works as it should. The `is_allowed_action` is defined as
```sql
CREATE OR REPLACE FUNCTION "public"."is_allowed_action"(apikey text, appid character varying)
```