### PR TITLE
feat: Filter out 'revert_to_builtin' storage_provider

### DIFF
--- a/src/api/versions.ts
+++ b/src/api/versions.ts
@@ -62,6 +62,7 @@ export async function getActiveAppVersions(supabase: SupabaseClient<Database>, a
     .select()
     .eq('app_id', appid)
     .eq('deleted', false)
+    .neq('storage_provider', 'revert_to_builtin')
     .order('created_at', { ascending: false })
 
   if (vError) {

--- a/src/channel/set.ts
+++ b/src/channel/set.ts
@@ -101,6 +101,7 @@ export async function setChannel(channel: string, appId: string, options: Option
         .eq('name', bundleVersion)
         .eq('user_id', userId)
         .eq('deleted', false)
+        .neq('storage_provider', 'revert_to_builtin')
         .single()
       if (vError || !data) {
         log.error(`Cannot find version ${bundleVersion}`)


### PR DESCRIPTION
Add condition to exclude versions with 'revert_to_builtin' storage provider in both version and channel queries. This ensures that these specific versions are not considered in the normal version listing and channel setting operations