### PR TITLE
fix: assume Capacitor V7 for linked versions of the updater

### DIFF
--- a/src/bundle/upload.ts
+++ b/src/bundle/upload.ts
@@ -237,6 +237,10 @@ async function prepareBundleFile(path: string, options: OptionsUpload, apikey: s
   else if (coerced) {
     isv7 = semverGte(coerced.version, '7.0.0')
   }
+  else if (updaterVersion === 'link:@capgo/capacitor-updater') {
+    log.warn('Using local @capgo/capacitor-updater. Assuming v7')
+    isv7 = true
+  }
   if (((keyV2 || options.keyDataV2 || existsSync(baseKeyV2)) && !noKey) || isv7) {
     checksum = await getChecksum(zipped, 'sha256')
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced update processing by accurately recognizing local updater configurations as version 7, resulting in improved compatibility and reduced warning messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->