### PR TITLE
feat: migrate build system from esbuild to Bun.build()

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -1,317 +1,341 @@
 import { copyFileSync, writeFileSync } from 'node:fs'
 import { env, exit } from 'node:process'
-import * as esbuild from 'esbuild'
+
+// Shared plugin definitions - Bun's plugin API is compatible with esbuild's
+const stubSemver = {
+  name: 'stub-semver',
+  setup(build) {
+    build.onResolve({ filter: /^semver$/ }, args => ({
+      path: args.path,
+      namespace: 'stub-semver',
+    }))
+    build.onLoad({ filter: /.*/, namespace: 'stub-semver' }, () => ({
+      contents: `
+        // Stub for semver package - @capacitor/cli requires it but checkPlatformVersions is never called
+        export const diff = () => null;
+        export const parse = () => null;
+        export const valid = () => null;
+        export const clean = () => null;
+        export const inc = () => null;
+        export const major = () => null;
+        export const minor = () => null;
+        export const patch = () => null;
+        export const compare = () => 0;
+        export const rcompare = () => 0;
+        export const gt = () => false;
+        export const lt = () => false;
+        export const eq = () => false;
+        export const neq = () => true;
+        export const gte = () => false;
+        export const lte = () => false;
+        export const satisfies = () => false;
+        export const maxSatisfying = () => null;
+        export const minSatisfying = () => null;
+        export const validRange = () => null;
+        export const outside = () => false;
+        export const gtr = () => false;
+        export const ltr = () => false;
+        export const intersects = () => false;
+        export const coerce = () => null;
+        export const Range = class Range {};
+        export const SemVer = class SemVer {};
+        export const Comparator = class Comparator {};
+      `,
+    }))
+  },
+}
+
+const ignorePunycode = {
+  name: 'ignore-punycode',
+  setup(build) {
+    build.onResolve({ filter: /^punycode$/ }, args => ({
+      path: args.path,
+      namespace: 'ignore',
+    }))
+    build.onLoad({ filter: /.*/, namespace: 'ignore' }, () => ({
+      contents: 'export default {}',
+    }))
+  },
+}
+
+const noopXml2js = {
+  name: 'noop-xml2js',
+  setup(build) {
+    build.onResolve({ filter: /^xml2js$/ }, args => ({
+      path: args.path,
+      namespace: 'noop',
+    }))
+    build.onLoad({ filter: /.*/, namespace: 'noop' }, () => ({
+      contents: 'export default {}',
+    }))
+  },
+}
+
+const noopIonicUtilsSubprocess = {
+  name: 'noop-ionic-utils-subprocess',
+  setup(build) {
+    build.onResolve({ filter: /@ionic\/utils-subprocess/ }, args => ({
+      path: args.path,
+      namespace: 'noop',
+    }))
+    build.onLoad({ filter: /.*/, namespace: 'noop' }, () => ({
+      contents: 'export default {}',
+    }))
+  },
+}
+
+const smartNoopIonicCliFrameworkOutput = {
+  name: 'smart-noop-ionic-cli-framework-output',
+  setup(build) {
+    build.onResolve({ filter: /@ionic\/cli-framework-output/ }, args => ({
+      path: args.path,
+      namespace: 'smart-noop-ionic-cli-framework-output',
+    }))
+    build.onLoad({ filter: /.*/, namespace: 'smart-noop-ionic-cli-framework-output' }, () => ({
+      contents: `
+        export const TTY_WIDTH = 80;
+        export const indent = (str) => str;
+        export const sliceAnsi = (str) => str;
+        export const stringWidth = (str) => str.length;
+        export const stripAnsi = (str) => str;
+        export const wordWrap = (str) => str;
+        export const createDefaultLogger = () => ({
+          info: console.log,
+          warn: console.warn,
+          error: console.error,
+          debug: console.debug,
+        });
+        export const NO_COLORS = {};
+        export class StreamOutputStrategy {
+          constructor() {
+            this.colors = NO_COLORS;
+            this.stream = process.stdout;
+          }
+        }
+        export class TTYOutputStrategy extends StreamOutputStrategy {
+          constructor(options) {
+            super();
+            this.options = options;
+          }
+        }
+        export class Logger {
+          constructor() {}
+          info() {}
+          warn() {}
+          error() {}
+          debug() {}
+        }
+        export const LOGGER_LEVELS = {
+          DEBUG: 'DEBUG',
+          INFO: 'INFO',
+          WARN: 'WARN',
+          ERROR: 'ERROR'
+        };
+      `,
+    }))
+  },
+}
+
+const noopSupabaseRealtimeJs = {
+  name: 'noop-supabase-realtime-js',
+  setup(build) {
+    build.onResolve({ filter: /@supabase\/realtime-js/ }, args => ({
+      path: args.path,
+      namespace: 'noop-supabase-realtime-js',
+    }))
+    build.onLoad({ filter: /.*/, namespace: 'noop-supabase-realtime-js' }, () => ({
+      contents: `
+        export class RealtimeClient {
+          constructor() {}
+          connect() {}
+          disconnect() {}
+        }
+      `,
+    }))
+  },
+}
+
+const stubPrompts = {
+  name: 'stub-prompts',
+  setup(build) {
+    build.onResolve({ filter: /^prompts$/ }, args => ({
+      path: args.path,
+      namespace: 'stub-prompts',
+    }))
+    build.onLoad({ filter: /.*/, namespace: 'stub-prompts' }, () => ({
+      contents: `
+        // Stub for prompts package - @capacitor/cli requires it but we don't use it
+        export default function prompts() {
+          throw new Error('Prompts are not supported in this CLI build');
+        }
+      `,
+    }))
+  },
+}
+
+const noopSupabaseAuthJs = {
+  name: 'noop-supabase-auth-js',
+  setup(build) {
+    build.onResolve({ filter: /@supabase\/auth-js/ }, args => ({
+      path: args.path,
+      namespace: 'noop-supabase-auth-js',
+    }))
+    build.onLoad({ filter: /.*/, namespace: 'noop-supabase-auth-js' }, () => ({
+      contents: `
+        // Stub for @supabase/auth-js - we don't use authentication, just API calls
+        const noopAsync = () => Promise.resolve({ data: { session: null, user: null }, error: null });
+        const noopHandler = {
+          get: (target, prop) => {
+            if (prop === 'constructor') return target.constructor;
+            if (prop === 'then' || prop === 'catch' || prop === 'finally') return undefined;
+            if (typeof prop === 'symbol') return undefined;
+            // Return method that returns properly structured promises
+            if (prop === 'getSession') return () => Promise.resolve({ data: { session: null, user: null }, error: null });
+            if (prop === 'onAuthStateChange') return () => ({ data: { subscription: { unsubscribe: () => {} } }, error: null });
+            return noopAsync;
+          }
+        };
+
+        export class GoTrueClient {
+          constructor(options) {
+            this.options = options;
+            return new Proxy(this, noopHandler);
+          }
+        }
+        export class GoTrueAdminApi {
+          constructor(options) {
+            this.options = options;
+            return new Proxy(this, noopHandler);
+          }
+        }
+        export class AuthClient extends GoTrueClient {}
+        export class AuthAdminApi extends GoTrueAdminApi {}
+
+        // Export error classes
+        export class AuthError extends Error {}
+        export class AuthApiError extends AuthError {}
+        export class AuthRetryableError extends AuthError {}
+        export class AuthSessionMissingError extends AuthError {}
+        export class AuthInvalidTokenResponseError extends AuthError {}
+        export class AuthInvalidCredentialsError extends AuthError {}
+        export class AuthImplicitGrantRedirectError extends AuthError {}
+        export class AuthPKCEGrantCodeExchangeError extends AuthError {}
+        export class AuthWeakPasswordError extends AuthError {}
+
+        // Export helper functions
+        export const navigatorLock = noopAsync;
+        export const processLock = noopAsync;
+        export class NavigatorLockAcquireTimeoutError extends Error {}
+        export const lockInternals = {};
+
+        // Export type helpers
+        export const isAuthError = () => false;
+        export const isAuthApiError = () => false;
+        export const isAuthRetryableError = () => false;
+        export const isAuthSessionMissingError = () => false;
+        export const isAuthWeakPasswordError = () => false;
+      `,
+    }))
+  },
+}
+
+const noopSupabaseNodeFetch = {
+  name: 'noop-supabase-node-fetch',
+  setup(build) {
+    build.onResolve({ filter: /@supabase\/node-fetch/ }, args => ({
+      path: args.path,
+      namespace: 'noop',
+    }))
+    build.onLoad({ filter: /.*/, namespace: 'noop' }, () => ({
+      contents: 'export default {}',
+    }))
+  },
+}
 
 // Build CLI
-const buildCLI = esbuild.build({
-  entryPoints: ['src/index.ts'],
-  bundle: true,
-  platform: 'node',
-  target: 'node20',
-  outfile: 'dist/index.js',
-  sourcemap: env.NODE_ENV === 'development',
-  metafile: true,
+const buildCLI = Bun.build({
+  entrypoints: ['src/index.ts'],
+  target: 'node',
+  outdir: 'dist',
+  naming: 'index.js',
+  sourcemap: env.NODE_ENV === 'development' ? 'linked' : 'none',
   minify: true,
-  treeShaking: true,
-  banner: {
-    js: '#!/usr/bin/env node',
-  },
   define: {
     'process.env.SUPA_DB': '"production"',
   },
-  loader: {
-    '.ts': 'ts',
-  },
   plugins: [
-    // Stub semver package (used by @capacitor/cli but checkPlatformVersions is never called)
-    {
-      name: 'stub-semver',
-      setup(build) {
-        build.onResolve({ filter: /^semver$/ }, args => ({
-          path: args.path,
-          namespace: 'stub-semver',
-        }))
-        build.onLoad({ filter: /.*/, namespace: 'stub-semver' }, () => ({
-          contents: `
-            // Stub for semver package - @capacitor/cli requires it but checkPlatformVersions is never called
-            export const diff = () => null;
-            export const parse = () => null;
-            export const valid = () => null;
-            export const clean = () => null;
-            export const inc = () => null;
-            export const major = () => null;
-            export const minor = () => null;
-            export const patch = () => null;
-            export const compare = () => 0;
-            export const rcompare = () => 0;
-            export const gt = () => false;
-            export const lt = () => false;
-            export const eq = () => false;
-            export const neq = () => true;
-            export const gte = () => false;
-            export const lte = () => false;
-            export const satisfies = () => false;
-            export const maxSatisfying = () => null;
-            export const minSatisfying = () => null;
-            export const validRange = () => null;
-            export const outside = () => false;
-            export const gtr = () => false;
-            export const ltr = () => false;
-            export const intersects = () => false;
-            export const coerce = () => null;
-            export const Range = class Range {};
-            export const SemVer = class SemVer {};
-            export const Comparator = class Comparator {};
-          `,
-        }))
-      },
-    },
-    // TOSO: remove this when fixed
-    {
-      name: 'ignore-punycode',
-      setup(build) {
-        build.onResolve({ filter: /^punycode$/ }, args => ({
-          path: args.path,
-          namespace: 'ignore',
-        }))
-        build.onLoad({ filter: /.*/, namespace: 'ignore' }, () => ({
-          contents: 'export default {}',
-        }))
-      },
-    },
-    // Noop xml2js as we only use capacitor-cli to read capacitor file nothing native
-    {
-      name: 'noop-xml2js',
-      setup(build) {
-        build.onResolve({ filter: /^xml2js$/ }, args => ({
-          path: args.path,
-          namespace: 'noop',
-        }))
-        build.onLoad({ filter: /.*/, namespace: 'noop' }, () => ({
-          contents: 'export default {}',
-        }))
-      },
-    },
-    // Noop @ionic/utils-subprocess
-    {
-      name: 'noop-ionic-utils-subprocess',
-      setup(build) {
-        build.onResolve({ filter: /@ionic\/utils-subprocess/ }, args => ({
-          path: args.path,
-          namespace: 'noop',
-        }))
-        build.onLoad({ filter: /.*/, namespace: 'noop' }, () => ({
-          contents: 'export default {}',
-        }))
-      },
-    },
-    // Smarter noop for @ionic/cli-framework-output
-    {
-      name: 'smart-noop-ionic-cli-framework-output',
-      setup(build) {
-        build.onResolve({ filter: /@ionic\/cli-framework-output/ }, args => ({
-          path: args.path,
-          namespace: 'smart-noop-ionic-cli-framework-output',
-        }))
-        build.onLoad({ filter: /.*/, namespace: 'smart-noop-ionic-cli-framework-output' }, () => ({
-          contents: `
-            export const TTY_WIDTH = 80;
-            export const indent = (str) => str;
-            export const sliceAnsi = (str) => str;
-            export const stringWidth = (str) => str.length;
-            export const stripAnsi = (str) => str;
-            export const wordWrap = (str) => str;
-            export const createDefaultLogger = () => ({
-              info: console.log,
-              warn: console.warn,
-              error: console.error,
-              debug: console.debug,
-            });
-            export const NO_COLORS = {};
-            export class StreamOutputStrategy {
-              constructor() {
-                this.colors = NO_COLORS;
-                this.stream = process.stdout;
-              }
-            }
-            export class TTYOutputStrategy extends StreamOutputStrategy {
-              constructor(options) {
-                super();
-                this.options = options;
-              }
-            }
-            export class Logger {
-              constructor() {}
-              info() {}
-              warn() {}
-              error() {}
-              debug() {}
-            }
-            export const LOGGER_LEVELS = {
-              DEBUG: 'DEBUG',
-              INFO: 'INFO',
-              WARN: 'WARN',
-              ERROR: 'ERROR'
-            };
-          `,
-        }))
-      },
-    },
-    // Noop @supabase/realtime-js
-    {
-      name: 'noop-supabase-realtime-js',
-      setup(build) {
-        build.onResolve({ filter: /@supabase\/realtime-js/ }, args => ({
-          path: args.path,
-          namespace: 'noop-supabase-realtime-js',
-        }))
-        build.onLoad({ filter: /.*/, namespace: 'noop-supabase-realtime-js' }, () => ({
-          contents: `
-            export class RealtimeClient {
-              constructor() {}
-              connect() {}
-              disconnect() {}
-            }
-          `,
-        }))
-      },
-    },
-    // Stub prompts package (used by @capacitor/cli but not needed in our use case)
-    {
-      name: 'stub-prompts',
-      setup(build) {
-        build.onResolve({ filter: /^prompts$/ }, args => ({
-          path: args.path,
-          namespace: 'stub-prompts',
-        }))
-        build.onLoad({ filter: /.*/, namespace: 'stub-prompts' }, () => ({
-          contents: `
-            // Stub for prompts package - @capacitor/cli requires it but we don't use it
-            export default function prompts() {
-              throw new Error('Prompts are not supported in this CLI build');
-            }
-          `,
-        }))
-      },
-    },
-    // Noop @supabase/auth-js (we don't use auth, just API calls with headers)
-    {
-      name: 'noop-supabase-auth-js',
-      setup(build) {
-        build.onResolve({ filter: /@supabase\/auth-js/ }, args => ({
-          path: args.path,
-          namespace: 'noop-supabase-auth-js',
-        }))
-        build.onLoad({ filter: /.*/, namespace: 'noop-supabase-auth-js' }, () => ({
-          contents: `
-            // Stub for @supabase/auth-js - we don't use authentication, just API calls
-            const noopAsync = () => Promise.resolve({ data: { session: null, user: null }, error: null });
-            const noopHandler = {
-              get: (target, prop) => {
-                if (prop === 'constructor') return target.constructor;
-                if (prop === 'then' || prop === 'catch' || prop === 'finally') return undefined;
-                if (typeof prop === 'symbol') return undefined;
-                // Return method that returns properly structured promises
-                if (prop === 'getSession') return () => Promise.resolve({ data: { session: null, user: null }, error: null });
-                if (prop === 'onAuthStateChange') return () => ({ data: { subscription: { unsubscribe: () => {} } }, error: null });
-                return noopAsync;
-              }
-            };
-
-            export class GoTrueClient {
-              constructor(options) {
-                this.options = options;
-                return new Proxy(this, noopHandler);
-              }
-            }
-            export class GoTrueAdminApi {
-              constructor(options) {
-                this.options = options;
-                return new Proxy(this, noopHandler);
-              }
-            }
-            export class AuthClient extends GoTrueClient {}
-            export class AuthAdminApi extends GoTrueAdminApi {}
-
-            // Export error classes
-            export class AuthError extends Error {}
-            export class AuthApiError extends AuthError {}
-            export class AuthRetryableError extends AuthError {}
-            export class AuthSessionMissingError extends AuthError {}
-            export class AuthInvalidTokenResponseError extends AuthError {}
-            export class AuthInvalidCredentialsError extends AuthError {}
-            export class AuthImplicitGrantRedirectError extends AuthError {}
-            export class AuthPKCEGrantCodeExchangeError extends AuthError {}
-            export class AuthWeakPasswordError extends AuthError {}
-
-            // Export helper functions
-            export const navigatorLock = noopAsync;
-            export const processLock = noopAsync;
-            export class NavigatorLockAcquireTimeoutError extends Error {}
-            export const lockInternals = {};
-
-            // Export type helpers
-            export const isAuthError = () => false;
-            export const isAuthApiError = () => false;
-            export const isAuthRetryableError = () => false;
-            export const isAuthSessionMissingError = () => false;
-            export const isAuthWeakPasswordError = () => false;
-          `,
-        }))
-      },
-    },
+    stubSemver,
+    ignorePunycode,
+    noopXml2js,
+    noopIonicUtilsSubprocess,
+    smartNoopIonicCliFrameworkOutput,
+    noopSupabaseRealtimeJs,
+    stubPrompts,
+    noopSupabaseAuthJs,
   ],
 })
 
 // Build SDK (separate bundle without CLI dependencies)
-const buildSDK = esbuild.build({
-  entryPoints: ['src/sdk.ts'],
-  bundle: true,
-  platform: 'node',
-  target: 'node20',
-  outfile: 'dist/src/sdk.js',
-  sourcemap: env.NODE_ENV === 'development',
-  metafile: true,
+const buildSDK = Bun.build({
+  entrypoints: ['src/sdk.ts'],
+  target: 'node',
+  outdir: 'dist/src',
+  naming: 'sdk.js',
+  sourcemap: env.NODE_ENV === 'development' ? 'linked' : 'none',
   minify: true,
-  treeShaking: true,
   format: 'cjs',
   define: {
     'process.env.SUPA_DB': '"production"',
   },
-  loader: {
-    '.ts': 'ts',
-  },
   plugins: [
-    // Same plugins as CLI but without banner
-    {
-      name: 'ignore-punycode',
-      setup(build) {
-        build.onResolve({ filter: /^punycode$/ }, args => ({
-          path: args.path,
-          namespace: 'ignore',
-        }))
-        build.onLoad({ filter: /.*/, namespace: 'ignore' }, () => ({
-          contents: 'export default {}',
-        }))
-      },
-    },
-    {
-      name: 'noop-supabase-node-fetch',
-      setup(build) {
-        build.onResolve({ filter: /@supabase\/node-fetch/ }, args => ({
-          path: args.path,
-          namespace: 'noop',
-        }))
-        build.onLoad({ filter: /.*/, namespace: 'noop' }, () => ({
-          contents: 'export default {}',
-        }))
-      },
-    },
+    ignorePunycode,
+    noopSupabaseNodeFetch,
   ],
 })
 
-Promise.all([buildCLI, buildSDK]).catch(() => exit(1)).then((results) => {
-  writeFileSync('meta.json', JSON.stringify(results[0].metafile))
+Promise.all([buildCLI, buildSDK]).then(async (results) => {
+  const [cliResult, sdkResult] = results
+
+  // Check for build errors
+  if (!cliResult.success) {
+    console.error('CLI build failed:')
+    for (const log of cliResult.logs) {
+      console.error(log)
+    }
+    exit(1)
+  }
+
+  if (!sdkResult.success) {
+    console.error('SDK build failed:')
+    for (const log of sdkResult.logs) {
+      console.error(log)
+    }
+    exit(1)
+  }
+
+  // Add shebang to CLI bundle
+  const cliOutput = await Bun.file('dist/index.js').text()
+  await Bun.write('dist/index.js', `#!/usr/bin/env node\n${cliOutput}`)
+
+  // Write metafile for bundle analysis (similar to esbuild's metafile)
+  // Use relative paths to match esbuild's format
+  const metafile = {
+    inputs: {},
+    outputs: {},
+  }
+  for (const output of cliResult.outputs) {
+    const relativePath = output.path.replace(process.cwd() + '/', '')
+    metafile.outputs[relativePath] = { bytes: output.size }
+  }
+  for (const output of sdkResult.outputs) {
+    const relativePath = output.path.replace(process.cwd() + '/', '')
+    metafile.outputs[relativePath] = { bytes: output.size }
+  }
+  writeFileSync('meta.json', JSON.stringify(metafile))
+
   copyFileSync('package.json', 'dist/package.json')
   console.error('✅ Built CLI and SDK successfully')
+}).catch((err) => {
+  console.error('Build failed:', err)
+  exit(1)
 })

--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,6 @@
         "adm-zip": "^0.5.16",
         "ci-info": "^4.3.1",
         "commander": "^14.0.2",
-        "esbuild": "^0.27.0",
         "eslint": "^9.38.0",
         "git-format-staged": "3.1.1",
         "husky": "^9.1.7",
@@ -65,58 +64,6 @@
     "@es-joy/jsdoccomment": ["@es-joy/jsdoccomment@0.78.0", "", { "dependencies": { "@types/estree": "^1.0.8", "@typescript-eslint/types": "^8.46.4", "comment-parser": "1.4.1", "esquery": "^1.6.0", "jsdoc-type-pratt-parser": "~7.0.0" } }, "sha512-rQkU5u8hNAq2NVRzHnIUUvR6arbO0b6AOlvpTNS48CkiKSn/xtNfOzBK23JE4SiW89DgvU7GtxLVgV4Vn2HBAw=="],
 
     "@es-joy/resolve.exports": ["@es-joy/resolve.exports@1.2.0", "", {}, "sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g=="],
-
-    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw=="],
-
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.2", "", { "os": "android", "cpu": "arm" }, "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA=="],
-
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.2", "", { "os": "android", "cpu": "arm64" }, "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA=="],
-
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.2", "", { "os": "android", "cpu": "x64" }, "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A=="],
-
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg=="],
-
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA=="],
-
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g=="],
-
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA=="],
-
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.2", "", { "os": "linux", "cpu": "arm" }, "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw=="],
-
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw=="],
-
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.2", "", { "os": "linux", "cpu": "ia32" }, "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w=="],
-
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.2", "", { "os": "linux", "cpu": "none" }, "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg=="],
-
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.2", "", { "os": "linux", "cpu": "none" }, "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw=="],
-
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ=="],
-
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.2", "", { "os": "linux", "cpu": "none" }, "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA=="],
-
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w=="],
-
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.2", "", { "os": "linux", "cpu": "x64" }, "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA=="],
-
-    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.2", "", { "os": "none", "cpu": "arm64" }, "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw=="],
-
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.2", "", { "os": "none", "cpu": "x64" }, "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA=="],
-
-    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA=="],
-
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg=="],
-
-    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.2", "", { "os": "none", "cpu": "arm64" }, "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag=="],
-
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg=="],
-
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg=="],
-
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ=="],
-
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.2", "", { "os": "win32", "cpu": "x64" }, "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ=="],
 
     "@eslint-community/eslint-plugin-eslint-comments": ["@eslint-community/eslint-plugin-eslint-comments@4.5.0", "", { "dependencies": { "escape-string-regexp": "^4.0.0", "ignore": "^5.2.4" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0" } }, "sha512-MAhuTKlr4y/CE3WYX26raZjy+I/kS2PLKSzvfmDCGrBLTFHOYwqROZdr4XwPgXwX3K9rjzMr4pSmUWGnzsUyMg=="],
 
@@ -421,8 +368,6 @@
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
-
-    "esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "node": ">=20.0.0"
   },
   "scripts": {
-    "build": "tsc && node build.mjs",
+    "build": "tsc && bun build.mjs",
     "dev": "NODE_ENV=development ncc build",
     "no-debug": "node dist/index.js",
     "dev-build": "SUPA_DB=development ncc build",
@@ -85,7 +85,6 @@
     "adm-zip": "^0.5.16",
     "ci-info": "^4.3.1",
     "commander": "^14.0.2",
-    "esbuild": "^0.27.0",
     "eslint": "^9.38.0",
     "git-format-staged": "3.1.1",
     "husky": "^9.1.7",

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -10,7 +10,7 @@ import { findSavedKey } from '../utils'
  * Format an SDK result error for MCP response.
  * Provides detailed error messages for security policy errors.
  */
-function formatMcpError<T>(result: SDKResult<T>): { content: Array<{ type: string, text: string }>, isError: true } {
+function formatMcpError<T>(result: SDKResult<T>): { content: Array<{ type: 'text', text: string }>, isError: true } {
   let errorMessage = result.error || 'Unknown error'
 
   // If it's a security policy error, use the detailed message
@@ -19,7 +19,7 @@ function formatMcpError<T>(result: SDKResult<T>): { content: Array<{ type: strin
   }
 
   return {
-    content: [{ type: 'text', text: errorMessage }],
+    content: [{ type: 'text' as const, text: errorMessage }],
     isError: true,
   }
 }
@@ -53,7 +53,7 @@ export async function startMcpServer(): Promise<void> {
       }
       return {
         content: [{
-          type: 'text',
+          type: 'text' as const,
           text: JSON.stringify(result.data, null, 2),
         }],
       }
@@ -74,7 +74,7 @@ export async function startMcpServer(): Promise<void> {
         return formatMcpError(result)
       }
       return {
-        content: [{ type: 'text', text: `Successfully added app: ${appId}` }],
+        content: [{ type: 'text' as const, text: `Successfully added app: ${appId}` }],
       }
     },
   )
@@ -94,7 +94,7 @@ export async function startMcpServer(): Promise<void> {
         return formatMcpError(result)
       }
       return {
-        content: [{ type: 'text', text: `Successfully updated app: ${appId}` }],
+        content: [{ type: 'text' as const, text: `Successfully updated app: ${appId}` }],
       }
     },
   )
@@ -111,7 +111,7 @@ export async function startMcpServer(): Promise<void> {
         return formatMcpError(result)
       }
       return {
-        content: [{ type: 'text', text: `Successfully deleted app: ${appId}` }],
+        content: [{ type: 'text' as const, text: `Successfully deleted app: ${appId}` }],
       }
     },
   )
@@ -149,7 +149,7 @@ export async function startMcpServer(): Promise<void> {
       }
       return {
         content: [{
-          type: 'text',
+          type: 'text' as const,
           text: JSON.stringify({
             message: 'Bundle uploaded successfully',
             bundleId: result.bundleId,
@@ -175,7 +175,7 @@ export async function startMcpServer(): Promise<void> {
       }
       return {
         content: [{
-          type: 'text',
+          type: 'text' as const,
           text: JSON.stringify(result.data, null, 2),
         }],
       }
@@ -195,7 +195,7 @@ export async function startMcpServer(): Promise<void> {
         return formatMcpError(result)
       }
       return {
-        content: [{ type: 'text', text: `Successfully deleted bundle: ${bundleId}` }],
+        content: [{ type: 'text' as const, text: `Successfully deleted bundle: ${bundleId}` }],
       }
     },
   )
@@ -223,7 +223,7 @@ export async function startMcpServer(): Promise<void> {
       }
       return {
         content: [{
-          type: 'text',
+          type: 'text' as const,
           text: JSON.stringify({
             message: 'Cleanup completed',
             removed: result.data?.removed,
@@ -253,7 +253,7 @@ export async function startMcpServer(): Promise<void> {
       }
       return {
         content: [{
-          type: 'text',
+          type: 'text' as const,
           text: JSON.stringify(result.data, null, 2),
         }],
       }
@@ -277,7 +277,7 @@ export async function startMcpServer(): Promise<void> {
       }
       return {
         content: [{
-          type: 'text',
+          type: 'text' as const,
           text: JSON.stringify(result.data, null, 2),
         }],
       }
@@ -304,7 +304,7 @@ export async function startMcpServer(): Promise<void> {
         return formatMcpError(result)
       }
       return {
-        content: [{ type: 'text', text: `Successfully created channel: ${channelId}` }],
+        content: [{ type: 'text' as const, text: `Successfully created channel: ${channelId}` }],
       }
     },
   )
@@ -347,7 +347,7 @@ export async function startMcpServer(): Promise<void> {
         return formatMcpError(result)
       }
       return {
-        content: [{ type: 'text', text: `Successfully updated channel: ${channelId}` }],
+        content: [{ type: 'text' as const, text: `Successfully updated channel: ${channelId}` }],
       }
     },
   )
@@ -366,7 +366,7 @@ export async function startMcpServer(): Promise<void> {
         return formatMcpError(result)
       }
       return {
-        content: [{ type: 'text', text: `Successfully deleted channel: ${channelId}` }],
+        content: [{ type: 'text' as const, text: `Successfully deleted channel: ${channelId}` }],
       }
     },
   )
@@ -385,7 +385,7 @@ export async function startMcpServer(): Promise<void> {
       }
       return {
         content: [{
-          type: 'text',
+          type: 'text' as const,
           text: JSON.stringify({ channel: channelId, currentBundle: result.data }, null, 2),
         }],
       }
@@ -407,7 +407,7 @@ export async function startMcpServer(): Promise<void> {
       }
       return {
         content: [{
-          type: 'text',
+          type: 'text' as const,
           text: JSON.stringify(result.data, null, 2),
         }],
       }
@@ -428,7 +428,7 @@ export async function startMcpServer(): Promise<void> {
       }
       return {
         content: [{
-          type: 'text',
+          type: 'text' as const,
           text: JSON.stringify({
             message: 'Organization created successfully',
             ...result.data,
@@ -453,7 +453,7 @@ export async function startMcpServer(): Promise<void> {
       }
       return {
         content: [{
-          type: 'text',
+          type: 'text' as const,
           text: JSON.stringify({ accountId: result.data }, null, 2),
         }],
       }
@@ -473,7 +473,7 @@ export async function startMcpServer(): Promise<void> {
       }
       return {
         content: [{
-          type: 'text',
+          type: 'text' as const,
           text: JSON.stringify(result.data, null, 2),
         }],
       }
@@ -503,7 +503,7 @@ export async function startMcpServer(): Promise<void> {
       }
       return {
         content: [{
-          type: 'text',
+          type: 'text' as const,
           text: JSON.stringify(result.data, null, 2),
         }],
       }
@@ -534,7 +534,7 @@ export async function startMcpServer(): Promise<void> {
       }
       return {
         content: [{
-          type: 'text',
+          type: 'text' as const,
           text: JSON.stringify({
             message: 'Build requested successfully',
             ...result.data,
@@ -561,7 +561,7 @@ export async function startMcpServer(): Promise<void> {
       }
       return {
         content: [{
-          type: 'text',
+          type: 'text' as const,
           text: 'Encryption keys generated successfully. Private key saved to .capgo_key_v2, public key to .capgo_key_v2.pub',
         }],
       }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,6 @@
     "typeRoots": ["src/types/*", "node_modules/@types"],
     "strict": true,
     "declaration": true,
-    "declarationMap": true,
     "emitDeclarationOnly": true,
     "outDir": "dist",
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary

Replace esbuild with Bun's native bundler. The Bun bundler uses an identical plugin API making the migration straightforward. Bundle sizes remain nearly identical (+1.1% on JS, same functionality).

Also fixes pre-existing TypeScript errors in src/mcp/server.ts where literal type 'text' was inferred as string, and removes declarationMap from tsconfig.json as map files are unnecessary for CLI distribution.

## Test plan

- Build completes successfully
- CLI commands work (--version, --help, doctor, app list, bundle list, channel list)
- SDK imports correctly with all 50+ exports available
- All existing tests pass (bundle, functional, semver validation)
- Bundle sizes verified: ~2.0MB JS (esbuild: 2.096MB, Bun: 2.120MB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)