### PR TITLE
fix: add "type": "module" to enable ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@capgo/cli",
   "version": "7.66.2",
+  "type": "module",
   "description": "A CLI to upload to capgo servers",
   "author": "Martin martin@capgo.app",
   "license": "Apache 2.0",


### PR DESCRIPTION
## Summary

The Bun.build migration outputs ESM format but package.json was missing the `"type": "module"` field. Node.js was incorrectly parsing the output as CommonJS, causing import statement errors when users ran `npx @capgo/cli`.

## Changes

- Added `"type": "module"` to package.json to properly declare ES module format

## Test plan

- All existing tests pass
- CLI runs correctly: `node dist/index.js --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to use ECMAScript modules (ESM). This enables native ESM behavior across the codebase and modernizes module resolution, which may affect how packages are imported or consumed and could require corresponding adjustments in build or runtime tooling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->