### PR TITLE
test: add CLI Node.js version compatibility test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,42 @@ env:
   CLICOLOR: 1
 
 jobs:
+  cli-node-compatibility:
+    name: CLI on Node.js ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['20', '21', '22', '23', '24', '25']
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Display Node.js version
+        run: node --version
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build CLI
+        run: bun run build
+
+      - name: Test CLI --version
+        run: node dist/index.js --version
+
+      - name: Test CLI --help
+        run: node dist/index.js --help
+
   typos:
     name: Check for typos
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a GitHub Actions matrix job to test the CLI against Node.js versions 20-25, ensuring compatibility across all supported versions from the minimum required version up to the latest.

The new `cli-node-compatibility` job runs in parallel and uses `fail-fast: false` to ensure all versions are tested even if one fails. Each test builds the CLI and verifies both `--version` and `--help` commands work correctly.