### PR TITLE
feat: add organization access info during app add

### DIFF
--- a/src/app/add.ts
+++ b/src/app/add.ts
@@ -171,7 +171,9 @@ export async function addAppInternal(
   }
 
   if (!silent) {
-    log.success(`App ${appId} added to Capgo. You can upload a bundle now`)
+    log.success(`App ${appId} added to Capgo`)
+    log.info(`This app is accessible to all members of your organization based on their permissions`)
+    log.info(`Next step: upload a bundle with "npx @capgo/cli bundle upload ${appId}"`)
     outro('Done ✅')
   }
 

--- a/src/init.ts
+++ b/src/init.ts
@@ -231,6 +231,7 @@ async function addAppStep(organization: Organization, apikey: string, appId: str
       else
         s.stop(`App add Done ✅`)
 
+      pLog.info(`This app is accessible to all members of your organization based on their permissions`)
       await markStep(organization.gid, apikey, 'add-app', currentAppId)
       return currentAppId
     }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,8 +1,8 @@
+import type { SDKResult } from '../sdk'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod'
 import pack from '../../package.json'
-import type { SDKResult } from '../sdk'
 import { CapgoSDK } from '../sdk'
 import { findSavedKey } from '../utils'
 

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1787,11 +1787,11 @@ export type { CapacitorConfig } from './config'
 export type { Database } from './types/supabase.types'
 export { createSupabaseClient } from './utils'
 export {
-  SECURITY_POLICY_ERRORS,
-  SECURITY_POLICY_MESSAGES,
+  formatApiErrorForCli,
+  getSecurityPolicyMessage,
   isSecurityPolicyError,
   parseSecurityPolicyError,
-  getSecurityPolicyMessage,
-  formatApiErrorForCli,
+  SECURITY_POLICY_ERRORS,
+  SECURITY_POLICY_MESSAGES,
 } from './utils/security_policy_errors'
-export type { SecurityPolicyErrorCode, ParsedSecurityError } from './utils/security_policy_errors'
+export type { ParsedSecurityError, SecurityPolicyErrorCode } from './utils/security_policy_errors'


### PR DESCRIPTION
## Summary
- Add organization access message when app is added via `app add` command
- Show explicit upload command to users (`bundle upload`)
- Display same message during `init` workflow

## Changes
- `src/app/add.ts`: Enhanced success output with org access info and next steps
- `src/init.ts`: Added org access info message in add app step

🤖 Generated with [Claude Code](https://claude.com/claude-code)