### PR TITLE
fix: send build_mode to backend in build request

### DIFF
--- a/src/build/request.ts
+++ b/src/build/request.ts
@@ -598,10 +598,12 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
     const requestPayload: {
       app_id: string
       platform: 'ios' | 'android'
+      build_mode?: 'debug' | 'release'
       credentials?: BuildCredentials
     } = {
       app_id: appId,
       platform: options.platform,
+      build_mode: options.buildMode,
     }
 
     // Validate required credentials for the platform


### PR DESCRIPTION
## Summary
- Fixed the `--build-mode` CLI option being silently ignored
- The option was defined but never included in the API request payload
- Now `--build-mode debug` actually creates debug builds instead of defaulting to release

## Test plan
- [ ] Run `npx @capgo/cli build request --platform ios --build-mode debug` and verify the backend receives `build_mode: "debug"`
- [ ] Run without `--build-mode` flag and verify it defaults to `release`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying build mode (debug or release) when creating native builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->