### PR TITLE
Add V3 checksum support for zip encrypt/decrypt

### DIFF
--- a/src/api/cryptoV2.ts
+++ b/src/api/cryptoV2.ts
@@ -101,6 +101,19 @@ export function decryptChecksumV2(checksum: string, key: string): string {
   return checksumDecrypted
 }
 
+export function decryptChecksumV3(checksum: string, key: string): string {
+  // V3: Correctly treats checksum as hex string and outputs hex
+  const checksumDecrypted = publicDecrypt(
+    {
+      key,
+      padding,
+    },
+    Buffer.from(checksum, formatHex),
+  ).toString(formatHex)
+
+  return checksumDecrypted
+}
+
 export interface RSAKeys {
   publicKey: string
   privateKey: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -225,6 +225,7 @@ Example: npx @capgo/cli@latest bundle encrypt ./myapp.zip CHECKSUM`)
   .option('--key <key>', `Custom path for private signing key`)
   .option('--key-data <keyData>', `Private signing key`)
   .option('-j, --json', `Output in JSON`)
+  .option('--package-json <packageJson>', optionDescriptions.packageJson)
 
 bundle
   .command('decrypt [zipPath] [checksum]')
@@ -237,6 +238,7 @@ Example: npx @capgo/cli@latest bundle decrypt ./myapp_encrypted.zip CHECKSUM`)
   .option('--key <key>', `Custom path for private signing key`)
   .option('--key-data <keyData>', `Private signing key`)
   .option('--checksum <checksum>', `Checksum of the bundle, to verify the integrity of the bundle`)
+  .option('--package-json <packageJson>', optionDescriptions.packageJson)
 
 bundle
   .command('zip [appId]')

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -359,6 +359,7 @@ export interface EncryptBundleOptions {
   keyPath?: string
   keyData?: string
   json?: boolean
+  packageJson?: string
 }
 
 export interface DecryptBundleOptions {
@@ -367,6 +368,7 @@ export interface DecryptBundleOptions {
   keyPath?: string
   keyData?: string
   checksum?: string
+  packageJson?: string
 }
 
 export interface ZipBundleOptions {
@@ -731,6 +733,7 @@ export class CapgoSDK {
         key: options.keyPath,
         keyData: options.keyData,
         json: options.json,
+        packageJson: options.packageJson,
       }, true)
 
       return {
@@ -749,6 +752,7 @@ export class CapgoSDK {
         key: options.keyPath,
         keyData: options.keyData,
         checksum: options.checksum,
+        packageJson: options.packageJson,
       }, true)
 
       return {


### PR DESCRIPTION
## Summary

- Added `decryptChecksumV3` function for hex-format checksums
- Encrypt/decrypt commands now auto-select V3 or V2 based on updater version (5.30.0+, 6.30.0+, 7.30.0+)
- Added `--package-json` option to CLI commands and SDK for custom package.json paths
- Maintains backward compatibility with older updater versions

## Test plan

- Build passes with no errors
- Zip encrypt/decrypt functions work with both old and new updater versions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added V3 checksum format support with automatic updater version detection
  * Introduced `--package-json` CLI option for bundle encrypt and decrypt commands to enable monorepo compatibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->