### PR TITLE
Cloud build: honor android.path/ios.path

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "test:mcp": "node test/test-mcp.mjs",
     "test:version-detection": "node test/test-get-installed-version.mjs",
     "test:version-detection:setup": "./test/fixtures/setup-test-projects.sh",
-    "test": "bun run test:bundle && bun run test:functional && bun run test:semver && bun run test:version-edge-cases && bun run test:regex && bun run test:upload && bun run test:credentials && bun run test:credentials-validation && bun run test:checksum && bun run test:esm-sdk && bun run test:mcp && bun run test:version-detection"
+    "test:platform-paths": "bun test/test-platform-paths.mjs",
+    "test": "bun run test:bundle && bun run test:functional && bun run test:semver && bun run test:version-edge-cases && bun run test:regex && bun run test:upload && bun run test:credentials && bun run test:credentials-validation && bun run test:checksum && bun run test:esm-sdk && bun run test:mcp && bun run test:version-detection && bun run test:platform-paths"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^7.0.0",

--- a/src/build/platform-paths.ts
+++ b/src/build/platform-paths.ts
@@ -1,0 +1,55 @@
+/**
+ * Platform Path Helpers
+ *
+ * Used by cloud build packaging to resolve custom Capacitor native project paths
+ * (e.g. android.path / ios.path) in monorepos.
+ */
+
+/**
+ * Normalize a user-configured relative path:
+ * - Converts Windows separators to forward slashes
+ * - Strips a leading "./"
+ * - Strips trailing slashes
+ * - Returns "" for "." / "./" / empty
+ */
+export function normalizeRelPath(input: string): string {
+  let s = `${input ?? ''}`.trim()
+  if (!s)
+    return ''
+
+  // Convert Windows separators to POSIX separators (zip paths are always "/")
+  if (s.includes('\\'))
+    s = s.split('\\').join('/')
+
+  // Collapse accidental duplicate separators (can happen with escaped paths)
+  while (s.includes('//'))
+    s = s.replace('//', '/')
+
+  // Strip leading "./" (repeatable)
+  while (s.startsWith('./'))
+    s = s.slice(2)
+
+  // Strip trailing "/" (repeatable)
+  while (s.endsWith('/'))
+    s = s.slice(0, -1)
+
+  if (s === '.')
+    return ''
+
+  return s
+}
+
+/**
+ * Get the platform directory to use inside the project zip based on Capacitor config.
+ * Falls back to the default platform directory ("ios" or "android") when not configured
+ * or when configured as ".".
+ */
+export function getPlatformDirFromCapacitorConfig(capConfig: any, platform: 'ios' | 'android'): string {
+  const configured = capConfig?.[platform]?.path
+  if (typeof configured === 'string' && configured.trim()) {
+    const normalized = normalizeRelPath(configured)
+    if (normalized)
+      return normalized
+  }
+  return platform
+}

--- a/test/test-platform-paths.mjs
+++ b/test/test-platform-paths.mjs
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict'
+import { getPlatformDirFromCapacitorConfig, normalizeRelPath } from '../src/build/platform-paths.ts'
+
+function t(name, fn) {
+  try {
+    fn()
+    process.stdout.write(`✓ ${name}\n`)
+  }
+  catch (e) {
+    process.stderr.write(`✗ ${name}\n`)
+    throw e
+  }
+}
+
+t('normalizeRelPath strips trailing slashes', () => {
+  assert.equal(normalizeRelPath('android/'), 'android')
+  assert.equal(normalizeRelPath('projects/app/android////'), 'projects/app/android')
+})
+
+t('normalizeRelPath strips leading ./', () => {
+  assert.equal(normalizeRelPath('./android'), 'android')
+  assert.equal(normalizeRelPath('././android/'), 'android')
+})
+
+t('normalizeRelPath normalizes windows separators', () => {
+  assert.equal(normalizeRelPath('projects\\app\\android\\'), 'projects/app/android')
+  assert.equal(normalizeRelPath('projects\\\\app\\\\android\\\\'), 'projects/app/android')
+})
+
+t('normalizeRelPath returns empty for "."', () => {
+  assert.equal(normalizeRelPath('.'), '')
+  assert.equal(normalizeRelPath('./'), '')
+  assert.equal(normalizeRelPath('  .  '), '')
+})
+
+t('getPlatformDirFromCapacitorConfig uses configured path', () => {
+  assert.equal(
+    getPlatformDirFromCapacitorConfig({ android: { path: 'projects/app/android' } }, 'android'),
+    'projects/app/android',
+  )
+})
+
+t('getPlatformDirFromCapacitorConfig falls back on "."', () => {
+  assert.equal(
+    getPlatformDirFromCapacitorConfig({ android: { path: '.' } }, 'android'),
+    'android',
+  )
+})
+
+process.stdout.write('OK\n')


### PR DESCRIPTION
Fix build request zipping to include native projects located via Capacitor android.path/ios.path (monorepos). Also inject a resolved capacitor.config.json into the zip when only TS/JS config is present, and load config relative to --path. Verified with bun run build, bun run test:mcp, and bun run test:bundle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced support for monorepo and workspace project structures in builds.
  * Improved platform-specific native dependency resolution for iOS and Android projects.
  * Increased build reliability with retry mechanisms for network operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->