### PR TITLE
fix(build): use explicit ws client for native log streaming on CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "tus-js-client": "^4.3.1",
     "typescript": "^5.9.3",
     "partysocket": "^1.1.11",
+    "ws": "^8.18.3",
     "zod": "^4.3.6"
   }
 }

--- a/src/build/request.ts
+++ b/src/build/request.ts
@@ -36,6 +36,7 @@ import process, { chdir, cwd, exit } from 'node:process'
 import { log, spinner as spinnerC } from '@clack/prompts'
 import AdmZip from 'adm-zip'
 import { WebSocket as PartySocket } from 'partysocket'
+import WS from 'ws'
 import * as tus from 'tus-js-client'
 import { createSupabaseClient, findSavedKey, getConfig, getOrganizationId, sendEvent, verifyUser } from '../utils'
 import { mergeCredentials } from './credentials'
@@ -240,7 +241,10 @@ async function streamBuildLogs(
       const maxRetries = 10
       let retryCount = 0
       let gaveUp = false
-      const ws = new PartySocket(websocketUrl, undefined, { maxRetries })
+      const ws = new PartySocket(websocketUrl, undefined, {
+        maxRetries,
+        WebSocket: WS,
+      })
       let heartbeatTimer: ReturnType<typeof setInterval> | null = null
       let lastConfirmedId = 0
       let lastMessageAt = Date.now()


### PR DESCRIPTION
## Summary
- instantiate PartySocket with an explicit `WebSocket: WS` option so Node/CI always uses the `ws` implementation for build-log streaming
- add `ws` to CLI dev dependencies to make the runtime dependency explicit and remove reliance on global WebSocket injection in CI workflows
- keep the change scoped to the native build log streaming path only (`src/build/request.ts`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated WebSocket implementation for build log streaming. Enhanced configuration with explicit provider settings and improved retry mechanisms to support more reliable and stable build logging functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->