### PR TITLE
fix(build): persist build status after WebSocket delivers terminal state

### DIFF
--- a/src/build/request.ts
+++ b/src/build/request.ts
@@ -1264,6 +1264,11 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
       // Only poll if we didn't get the final status from the stream
       if (streamStatus) {
         finalStatus = streamStatus
+        // Persist terminal status to the database via /build/status.
+        // The WebSocket only delivers status to the CLI — calling the API
+        // endpoint triggers the backend to write status + last_error into build_requests.
+        if (TERMINAL_STATUS_SET.has(streamStatus))
+          await statusCheck().catch(() => {})
       }
       else {
         // Fall back to polling if stream ended without final status


### PR DESCRIPTION
## Summary (AI generated)

- After the WebSocket stream delivers a terminal build status (succeeded/failed/etc.), call `/build/status` once to persist the result into `build_requests`

## Motivation (AI generated)

The WebSocket stream delivers the build status directly to the CLI, which then exits without calling `/build/status`. That API endpoint is what triggers the backend to write `status` and `last_error` into the `build_requests` table.

Result: the dashboard shows builds stuck at "pending" with no error details, even though the CLI correctly displayed the final status.

This is the CLI-side complement to [Cap-go/capgo#1637](https://github.com/Cap-go/capgo/pull/1637) which fixes the backend to use `supabaseAdmin` for the update.

## Business Impact (AI generated)

- Build status and error details now reliably appear in the dashboard after every CLI build
- Users can diagnose build failures from the web UI instead of relying solely on CLI output

## Test Plan (AI generated)

- [ ] Run a build via CLI, verify `/build/status` is called after WebSocket delivers terminal status
- [ ] Confirm `build_requests` row in Supabase has correct `status` and `last_error` after build completes
- [ ] Verify the `.catch(() => {})` prevents any network error from breaking the CLI exit flow
- [ ] `bun run test:mcp` passes
- [ ] `bun run test:bundle` passes

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Build terminal states now reliably persist to the backend, ensuring accurate and consistent status records across all completion outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->