### PR TITLE
fix(ci): set git user name for docs push

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -70,6 +70,7 @@ jobs:
           destination-repository-name: website
           target-directory: src/content/docs/docs/cli/reference
           target-branch: main
+          user-name: github-actions[bot]
           user-email: martindonadieu@gmail.com
   create-cache:
     if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}


### PR DESCRIPTION
This updates the release bump workflow to set an explicit git user name for the docs sync push action. The workflow already set user email, but missing user name could cause commits to fail with an empty ident error in CI. The PR diff only changes `.github/workflows/bump_version.yml` by adding `user-name: github-actions[bot]` to the push step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to specify user permissions for documentation publishing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->