### PR TITLE
fix(init): save app ID to CapacitorUpdater plugin config instead of global config

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -16,7 +16,6 @@ import { addChannelInternal } from './channel/add'
 import { createKeyInternal } from './key'
 import { doLoginExists, loginInternal } from './login'
 import { createSupabaseClient, findBuildCommandForProjectType, findMainFile, findMainFileForProjectType, findProjectType, findRoot, findSavedKey, getAllPackagesDependencies, getAppId, getBundleVersion, getConfig, getInstalledVersion, getLocalConfig, getOrganization, getPackageScripts, getPMAndCommand, PACKNAME, projectIsMonorepo, promptAndSyncCapacitor, updateConfigbyKey, updateConfigUpdater, validateIosUpdaterSync, verifyUser } from './utils'
-import { writeConfig } from './config'
 
 interface SuperOptions extends Options {
   local: boolean
@@ -171,16 +170,12 @@ async function markStep(orgId: string, apikey: string, step: string, appId: stri
 }
 
 /**
- * Save the app ID to the capacitor config file.
+ * Save the app ID to the CapacitorUpdater plugin config.
  */
 async function saveAppIdToCapacitorConfig(appId: string) {
   try {
-    const extConfig = await getConfig()
-    if (extConfig?.config) {
-      extConfig.config.appId = appId
-      await writeConfig('CapacitorUpdater', extConfig, true)
-      pLog.info(`💾 Saved new app ID "${appId}" to capacitor config`)
-    }
+    await updateConfigUpdater({ appId })
+    pLog.info(`💾 Saved new app ID "${appId}" to CapacitorUpdater config`)
   }
   catch (err) {
     pLog.warn(`⚠️  Could not save app ID to capacitor config: ${err}`)


### PR DESCRIPTION
## Summary (AI generated)

Fixes the `saveAppIdToCapacitorConfig()` function to save the new app ID to the CapacitorUpdater plugin config (`config.plugins.CapacitorUpdater.appId`) instead of the global capacitor config (`config.appId`).

## Motivation (AI generated)

The previous implementation (#503) saved the app ID to the wrong location in the config file. The CapacitorUpdater plugin reads its configuration from `config.plugins.CapacitorUpdater`, not from the global `config.appId`. This meant that even though the app ID was being saved, it wouldn't be picked up by the updater plugin properly.

## Business Impact (AI generated)

- **Correct configuration**: The app ID is now saved in the correct location where CapacitorUpdater can read it
- **Consistent with existing patterns**: Uses the same `updateConfigUpdater()` function used elsewhere in the codebase
- **Removes unused import**: Cleans up the `writeConfig` import that was only used by the previous implementation

## Changes (AI generated)

- Changed `saveAppIdToCapacitorConfig()` to use `updateConfigUpdater({ appId })` instead of manually setting `extConfig.config.appId`
- Removed the unused `writeConfig` import from `./config`
- Updated the function comment to reflect the correct behavior
- Updated the success message to say "CapacitorUpdater config" instead of "capacitor config"

## Test Plan (AI generated)

- [ ] Test `capgo init` with an app ID that already exists in Capgo
- [ ] Select a new app ID and verify it's saved to `capacitor.config.ts` under `plugins.CapacitorUpdater.appId`
- [ ] Verify the saved app ID is properly read by subsequent CLI commands
- [ ] Verify no regression in the init flow

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling with clearer messaging when updating application configuration, including helpful hints for manual updates when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->