### PR TITLE
fix: validate app ID suggestions before showing to users

### DIFF
--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -10,6 +10,22 @@ export async function checkAppExists(supabase: SupabaseClient<Database>, appid: 
   return !!app
 }
 
+/**
+ * Check multiple app IDs at once for batch validation (e.g., for suggestions)
+ */
+export async function checkAppIdsExist(supabase: SupabaseClient<Database>, appids: string[]) {
+  const results = await Promise.all(
+    appids.map(async (appid) => {
+      const { data: app } = await supabase
+        .rpc('exist_app_v2', { appid })
+        .single()
+      return { appid, exists: !!app }
+    })
+  )
+  return results
+}
+
+
 export async function check2FAComplianceForApp(
   supabase: SupabaseClient<Database>,
   appid: string,


### PR DESCRIPTION
## Summary (AI generated)

- Add `checkAppIdsExist` function to batch check multiple app IDs against the database
- Modify onboarding flow to validate suggestions before displaying them to ensure they are available
- Add more diverse suggestion formats (random suffix, `.dev`, timestamp-based)
- If no suggestions are available, prompt user for custom input instead of showing taken IDs

## Motivation (AI generated)

When a user tries to create an app with an app ID that is already taken, the onboarding flow suggests alternative app IDs. However, these suggestions were not validated against the database, meaning they could also be taken, leading to a poor user experience where users might select an alternative that also fails.

## Business Impact (AI generated)

This improves user experience by ensuring that suggested app IDs are actually available, reducing friction during onboarding and decreasing the number of failed app creation attempts.

## Test Plan (AI generated)

- [ ] Test onboarding flow with a taken app ID and verify suggestions are validated
- [ ] Verify that only available suggestions are shown to users
- [ ] Test the fallback to custom input when no suggestions are available
- [ ] Verify diverse suggestion formats work correctly

Generated with AI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * App ID suggestions now dynamically validated against the database to show only available options.
  * Custom App ID input now includes format validation requirements (non-empty, reverse-domain notation format).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->