### PR TITLE
fix: support main.tsx for React/Vite projects in auto code injection

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -947,7 +947,14 @@ export function findMainFileForProjectType(projectType: string, isTypeScript: bo
     return isTypeScript ? 'src/main.ts' : 'src/main.js'
   }
   if (projectType === 'react-js' || projectType === 'react-ts') {
-    return isTypeScript ? 'src/index.tsx' : 'src/index.js'
+    // Vite React projects commonly use src/main.tsx, while CRA uses src/index.tsx
+    // Check for main first, then fall back to index
+    const mainExt = isTypeScript ? 'src/main.tsx' : 'src/main.js'
+    const indexExt = isTypeScript ? 'src/index.tsx' : 'src/index.js'
+    if (existsSync(resolve(cwd(), mainExt))) {
+      return mainExt
+    }
+    return indexExt
   }
   return null
 }


### PR DESCRIPTION
## Summary

- Fix CLI auto code injection to support `main.tsx` for React/Vite projects
- Previously the CLI only looked for `src/index.tsx` which is used by CRA, but Vite React projects commonly use `src/main.tsx` as the entry point
- The fix checks for `main.tsx` first, then falls back to `index.tsx`

## Changes

- Modified `findMainFileForProjectType` function in `src/utils.ts` to check for both `main.tsx` and `index.tsx` for React projects

## Testing

- Build verified: `npm run build` passes
- TypeScript compilation verified: `npx tsc --noEmit` passes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved React project entry point detection to prioritize modern framework conventions when available, with automatic fallback to traditional project layouts. This enhances compatibility across different React project setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->