### PR TITLE
fix: remove duplicate Capacitor sync prompt during init

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -781,27 +781,6 @@ async function addEncryptionStep(orgId: string, apikey: string, appId: string) {
       s.stop(`key created 🔑`)
     }
 
-    // Ask user if they want to sync with Capacitor after key creation
-    // Pass true for isInit flag to track cancellation during onboarding flow
-    // orgId and apikey are needed to mark snag if user cancels
-    try {
-      await promptAndSyncCapacitor(true, orgId, apikey, {
-        validateIosUpdater: true,
-        packageJsonPath: globalPathToPackageJson,
-      })
-      markSnag('onboarding-v2', orgId, apikey, 'Use encryption v2', appId)
-    }
-    catch (error) {
-      // Only handle cancellation gracefully - re-throw any other errors
-      if (error instanceof Error && error.message === 'Capacitor sync cancelled') {
-        // User cancelled the sync - cancellation is already tracked in promptAndSyncCapacitor
-        // Just continue without marking the successful completion
-      }
-      else {
-        // Re-throw any other errors (e.g., network errors, permission errors, etc.)
-        throw error
-      }
-    }
   }
   await markStep(orgId, apikey, 'add-encryption', appId)
 }


### PR DESCRIPTION
## Summary

- Removes duplicate Capacitor sync prompt during the `init` onboarding flow
- The sync was being asked twice: once inside `createKeyInternal` and once directly in `addEncryptionStep`

## Problem

When running `npx @capgo/cli@latest init`, users were prompted:
```
key created 🔑
→ "Would you like to sync?" → [Yes]
→ "Capacitor sync completed ✅"
→ "Would you like to sync?" → [Yes/No]  ← DUPLICATE!
→ "Done ✅"
```

## Solution

Since `createKeyInternal` already calls `promptAndSyncCapacitor` with proper iOS validation, the duplicate call in `addEncryptionStep` is removed.

## Testing

- [x] Code compiles without errors
- [ ] Manual testing of init flow (to verify single prompt appears)