### PR TITLE
fix: detect app start failure and prompt to open IDE

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -891,8 +891,9 @@ async function runDeviceStep(orgId: string, apikey: string, appId: string, platf
     const runFailed = runResult.error || runResult.status !== 0
 
     if (runFailed) {
+      const platformName = platform === 'ios' ? 'iOS' : 'Android'
       s.stop(`App failed to start ❌`)
-      pLog.error(`The app failed to start on your ${platform} device.`)
+      pLog.error(`The app failed to start on your ${platformName} device.`)
 
       const openIDE = await pConfirm({
         message: `Would you like to open ${platform === 'ios' ? 'Xcode' : 'Android Studio'} to run the app manually?`,


### PR DESCRIPTION
## Summary

- Detect deployment failures by checking exit code after `cap run` 
- Show clear "App failed to start" message instead of blind "App started ✅"
- Prompt user to open Xcode/Android Studio manually if deployment fails
- Run `cap open ios/android` automatically if user confirms

This fixes the issue where the CLI would always show "App started ✅" even when the deployment actually failed (e.g., due to missing DerivedData path).