### PR TITLE
fix: remove 'test' from react project log message

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -919,7 +919,7 @@ export async function findProjectType() {
       const dependencies = await getAllPackagesDependencies(folder)
       if (dependencies) {
         if (dependencies.get('react')) {
-          log.info('Found react project test')
+          log.info('Found react project')
           return isTypeScript ? 'react-ts' : 'react-js'
         }
         if (dependencies.get('vue')) {


### PR DESCRIPTION
## Summary
- Remove the word "test" from the react project detection log message for consistency with other framework detection messages (e.g., "Found vue project")

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated log message for project type detection to accurately reflect the detected project type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->