### PR TITLE
fix(init): ignore checksum check during onboarding upload

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -1203,6 +1203,7 @@ async function uploadStep(orgId: string, apikey: string, appId: string, newVersi
       nodeModules: isMonorepo ? nodeModulesPath : undefined,
       deltaOnly: delta,
       bundle: newVersion,
+      ignoreChecksumCheck: true,
     }, false)
     if (!uploadRes?.success) {
       s.stop('Error')


### PR DESCRIPTION
## Summary
- During `capgo init` onboarding, bundle uploads now automatically pass `--ignore-checksum-check` to prevent failures when re-running onboarding or when the channel already has a bundle with the same checksum

## Changes
- Added `ignoreChecksumCheck: true` to the `uploadBundleInternal` call in `src/init.ts` during the upload step of onboarding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted bundle upload verification settings to improve upload handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->