### PR TITLE
fix(init): restore logsnag tracking for encryption v2 usage

### DIFF
--- a/src/init.ts
+++ b/src/init.ts
@@ -815,6 +815,7 @@ async function addEncryptionStep(orgId: string, apikey: string, appId: string) {
     else {
       s.stop(`key created 🔑`)
     }
+    await markSnag('onboarding-v2', orgId, apikey, 'Use encryption v2', appId)
 
   }
   await markStep(orgId, apikey, 'add-encryption', appId)


### PR DESCRIPTION
## Summary

Restores the `markSnag` call for tracking encryption v2 usage in the onboarding flow that was inadvertently removed in PR #509.

## Problem

PR #509 removed the duplicate Capacitor sync prompt, but it also removed the `markSnag` call that tracks when users enable encryption v2 during onboarding.

## Solution

Restore just the `markSnag` call without restoring the duplicate sync prompt:

```typescript
await markSnag('onboarding-v2', orgId, apikey, 'Use encryption v2', appId)
```

This ensures we continue to track encryption v2 usage metrics while still keeping the fix from PR #509 (removing duplicate sync prompt).

## Testing

- [x] Code compiles without errors
- [ ] Verify the logsnag event fires when encryption is enabled during init

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced onboarding tracking for encryption setup to capture user progress through the encryption v2 workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->