### PR TITLE
fix(init): stop spinners on error to prevent hanging during onboarding

### DIFF
--- a/test/test-functional.mjs
+++ b/test/test-functional.mjs
@@ -176,19 +176,8 @@ try {
     const stderr = e.stderr?.toString() || ''
     const stdout = e.stdout?.toString() || ''
 
-    // Check if the error is the __dirname bug we're trying to prevent.
-    // Note: stack traces naturally contain /home/runner/work/ since that's the
-    // actual runtime path of the CLI on CI. We filter those out to avoid false
-    // positives. The real bug would show ENOENT errors trying to resolve
-    // node_modules at a CI build-time path (not just the CLI's own location).
-    const filterStackTraces = (text) => text.split('\n')
-      .filter(line => !line.match(/^\s*(at |-)/) && !line.includes('file:///'))
-      .join('\n')
-
-    const filteredStderr = filterStackTraces(stderr)
-    const filteredStdout = filterStackTraces(stdout)
-
-    if (filteredStderr.includes('/home/runner/work/') || filteredStdout.includes('/home/runner/work/')) {
+    // Check if the error is the __dirname bug we're trying to prevent
+    if (stderr.includes('/home/runner/work/') || stdout.includes('/home/runner/work/')) {
       console.error('❌ CRITICAL: CLI has hardcoded CI paths!')
       console.error('   Error output:', stderr || stdout)
       throw new Error('Hardcoded CI path detected in CLI runtime')


### PR DESCRIPTION
## Summary

- Wraps `addAppInternal()`, `addChannelInternal()`, and `loginInternal()` calls in try/catch blocks that call `spinner.stop()` before re-throwing errors
- Prevents `@clack/prompts` spinners from hanging indefinitely when any of these async operations fail during onboarding

## Problem

During CLI onboarding (`npx @capgo/cli init`), if an error occurs while adding an app, creating a channel, or logging in, the spinner keeps running forever because `spinner.stop()` is never called on the error path.

## Solution

Added try/catch wrappers around each vulnerable spinner section:
1. **`addAppStep`** — inner try/catch around `addAppInternal()` stops spinner with "App add failed ❌" before re-throwing to the outer retry logic
2. **`addChannelStep`** — try/catch around `addChannelInternal()` stops spinner with "Channel creation failed ❌"  
3. **`initApp` login** — try/catch around `loginInternal()` stops spinner with "Login failed ❌"

All three re-throw the error after stopping the spinner so existing error handling continues to work.

## Testing

- `bun run test:mcp` ✅
- `bun run test:bundle` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved startup error handling: failures during app add, channel creation, and login now emit clear failure messages (e.g., "App add failed ❌", "Channel creation failed ❌", "Login failed ❌") and are consistently propagated to halt or escalate the flow.

* **Tests**
  * Reduced false positives in functional tests by filtering stack-trace noise from outputs before checks, yielding more reliable test results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->