### PR TITLE
fix: resolve lint errors for CI

### DIFF
--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -20,11 +20,10 @@ export async function checkAppIdsExist(supabase: SupabaseClient<Database>, appid
         .rpc('exist_app_v2', { appid })
         .single()
       return { appid, exists: !!app }
-    })
+    }),
   )
   return results
 }
-
 
 export async function check2FAComplianceForApp(
   supabase: SupabaseClient<Database>,

--- a/src/bundle/upload.ts
+++ b/src/bundle/upload.ts
@@ -17,11 +17,11 @@ import { check2FAComplianceForApp, checkAppExistsAndHasPermissionOrgErr } from '
 import { calcKeyId, encryptChecksum, encryptChecksumV3, encryptSource, generateSessionKey } from '../api/crypto'
 import { checkAlerts } from '../api/update'
 import { getChecksum } from '../checksum'
+import { showReplicationProgress } from '../replicationProgress'
 import { baseKeyV2, BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, checkChecksum, checkCompatibilityCloud, checkPlanValidUpload, checkRemoteCliMessages, createSupabaseClient, deletedFailedVersion, findRoot, findSavedKey, formatError, getAppId, getBundleVersion, getCompatibilityDetails, getConfig, getInstalledVersion, getLocalConfig, getLocalDependencies, getOrganizationId, getPMAndCommand, getRemoteFileConfig, hasOrganizationPerm, isCompatible, isDeprecatedPluginVersion, OrganizationPerm, regexSemver, sendEvent, updateConfigUpdater, updateOrCreateChannel, updateOrCreateVersion, UPLOAD_TIMEOUT, uploadTUS, uploadUrl, verifyUser, zipFile } from '../utils'
 import { getVersionSuggestions, interactiveVersionBump } from '../versionHelpers'
 import { checkIndexPosition, searchInDirectory } from './check'
 import { prepareBundlePartialFiles, uploadPartial } from './partial'
-import { showReplicationProgress } from '../replicationProgress'
 
 type SupabaseType = Awaited<ReturnType<typeof createSupabaseClient>>
 type pmType = ReturnType<typeof getPMAndCommand>

--- a/src/init.ts
+++ b/src/init.ts
@@ -17,7 +17,7 @@ import { addChannelInternal } from './channel/add'
 import { createKeyInternal } from './key'
 import { doLoginExists, loginInternal } from './login'
 import { showReplicationProgress } from './replicationProgress'
-import { createSupabaseClient, findBuildCommandForProjectType, findMainFile, findMainFileForProjectType, findProjectType, findRoot, findSavedKey, getAllPackagesDependencies, getAppId, getBundleVersion, getConfig, getInstalledVersion, getLocalConfig, getOrganization, getPackageScripts, getPMAndCommand, PACKNAME, projectIsMonorepo, promptAndSyncCapacitor, updateConfigbyKey, updateConfigUpdater, validateIosUpdaterSync, verifyUser } from './utils'
+import { createSupabaseClient, findBuildCommandForProjectType, findMainFile, findMainFileForProjectType, findProjectType, findRoot, findSavedKey, getAllPackagesDependencies, getAppId, getBundleVersion, getConfig, getInstalledVersion, getLocalConfig, getOrganization, getPackageScripts, getPMAndCommand, PACKNAME, projectIsMonorepo, updateConfigbyKey, updateConfigUpdater, validateIosUpdaterSync, verifyUser } from './utils'
 
 interface SuperOptions extends Options {
   local: boolean

--- a/src/replicationProgress.ts
+++ b/src/replicationProgress.ts
@@ -1,3 +1,4 @@
+import process from 'node:process'
 import { log, spinner as spinnerC } from '@clack/prompts'
 
 interface DeploymentRegion {


### PR DESCRIPTION
## Summary
- Add missing `import process from 'node:process'` in `replicationProgress.ts` to fix `node/prefer-global/process` lint rule
- Includes auto-fixed import ordering and formatting from `eslint --fix`

## Context
CI on main is failing due to lint errors introduced in commit 0a964ad. This fixes them so the release pipeline can proceed.

## Test plan
- [x] `bun run lint` passes locally
- [x] `npm run build` compiles successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized imports and cleaned up internal code structure across multiple modules for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->