### PR TITLE
feat: add --ios-scheme and --ios-target options

### DIFF
--- a/src/build/credentials.ts
+++ b/src/build/credentials.ts
@@ -185,6 +185,8 @@ export function loadCredentialsFromEnv(): Partial<BuildCredentials> {
   const appleKeyContent = readRuntimeEnv('APPLE_KEY_CONTENT')
   const appleProfileName = readRuntimeEnv('APPLE_PROFILE_NAME')
   const appStoreConnectTeamId = readRuntimeEnv('APP_STORE_CONNECT_TEAM_ID')
+  const capgoIosScheme = readRuntimeEnv('CAPGO_IOS_SCHEME')
+  const capgoIosTarget = readRuntimeEnv('CAPGO_IOS_TARGET')
   const androidKeystoreFile = readRuntimeEnv('ANDROID_KEYSTORE_FILE')
   const keystoreKeyAlias = readRuntimeEnv('KEYSTORE_KEY_ALIAS')
   const keystoreKeyPassword = readRuntimeEnv('KEYSTORE_KEY_PASSWORD')
@@ -212,6 +214,10 @@ export function loadCredentialsFromEnv(): Partial<BuildCredentials> {
     credentials.APPLE_PROFILE_NAME = appleProfileName
   if (appStoreConnectTeamId)
     credentials.APP_STORE_CONNECT_TEAM_ID = appStoreConnectTeamId
+  if (capgoIosScheme)
+    credentials.CAPGO_IOS_SCHEME = capgoIosScheme
+  if (capgoIosTarget)
+    credentials.CAPGO_IOS_TARGET = capgoIosTarget
 
   // Android credentials
   if (androidKeystoreFile)

--- a/src/build/request.ts
+++ b/src/build/request.ts
@@ -926,6 +926,10 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
       cliCredentials.APPLE_PROFILE_NAME = options.appleProfileName
     if (options.appStoreConnectTeamId)
       cliCredentials.APP_STORE_CONNECT_TEAM_ID = options.appStoreConnectTeamId
+    if (options.iosScheme)
+      cliCredentials.CAPGO_IOS_SCHEME = options.iosScheme
+    if (options.iosTarget)
+      cliCredentials.CAPGO_IOS_TARGET = options.iosTarget
     if (options.androidKeystoreFile)
       cliCredentials.ANDROID_KEYSTORE_FILE = options.androidKeystoreFile
     if (options.keystoreKeyAlias)

--- a/src/index.ts
+++ b/src/index.ts
@@ -732,6 +732,8 @@ Example: npx @capgo/cli@latest build request com.example.app --platform ios --pa
   .option('--apple-key-content <content>', 'iOS: Base64-encoded App Store Connect API key (.p8)')
   .option('--apple-profile-name <name>', 'iOS: Provisioning profile name')
   .option('--app-store-connect-team-id <id>', 'iOS: App Store Connect Team ID')
+  .option('--ios-scheme <scheme>', 'iOS: Xcode scheme to build (default: App)')
+  .option('--ios-target <target>', 'iOS: Xcode target for reading build settings (default: same as scheme)')
   // Android credential CLI options (can also be set via env vars or saved credentials)
   .option('--android-keystore-file <keystore>', 'Android: Base64-encoded keystore file')
   .option('--keystore-key-alias <alias>', 'Android: Keystore key alias')

--- a/src/schemas/build.ts
+++ b/src/schemas/build.ts
@@ -16,6 +16,8 @@ export const buildCredentialsSchema = z.object({
   APPLE_KEY_CONTENT: z.string().optional(),
   APPLE_PROFILE_NAME: z.string().optional(),
   APP_STORE_CONNECT_TEAM_ID: z.string().optional(),
+  CAPGO_IOS_SCHEME: z.string().optional(),
+  CAPGO_IOS_TARGET: z.string().optional(),
   // Android credentials
   ANDROID_KEYSTORE_FILE: z.string().optional(),
   KEYSTORE_KEY_ALIAS: z.string().optional(),
@@ -47,6 +49,8 @@ export const buildRequestOptionsSchema = optionsBaseSchema.extend({
   appleKeyContent: z.string().optional(),
   appleProfileName: z.string().optional(),
   appStoreConnectTeamId: z.string().optional(),
+  iosScheme: z.string().optional(),
+  iosTarget: z.string().optional(),
   // Android credential options (flattened)
   androidKeystoreFile: z.string().optional(),
   keystoreKeyAlias: z.string().optional(),


### PR DESCRIPTION
## Summary
- Add `--ios-scheme` and `--ios-target` CLI options for users with custom Xcode targets (e.g. prod, staging, RC environments sharing one Capacitor project)
- Wire options through schema validation, credential merging, and env var loading (`CAPGO_IOS_SCHEME`, `CAPGO_IOS_TARGET`)
- Defaults to `"App"` for backwards compatibility with standard Capacitor projects

## Companion PR
- capgo_builder: https://github.com/Cap-go/capgo_builder/pull/25

## Test plan
- [ ] Build CLI succeeds (`npm run build`)
- [ ] Without `--ios-scheme`/`--ios-target`, behavior is unchanged (defaults to "App")
- [ ] With `--ios-scheme "X"`, credentials payload includes `CAPGO_IOS_SCHEME=X`
- [ ] With both `--ios-scheme "X" --ios-target "Y"`, both values in payload
- [ ] Env vars `CAPGO_IOS_SCHEME`/`CAPGO_IOS_TARGET` are loaded from environment
- [ ] End-to-end preprod test with custom scheme/target project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--ios-scheme` and `--ios-target` CLI options to specify Xcode build settings for iOS builds (scheme defaults to "App")
  * Added `CAPGO_IOS_SCHEME` and `CAPGO_IOS_TARGET` environment variables for configuring iOS build parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->