### PR TITLE
feat: default BUILD_OUTPUT_UPLOAD_ENABLED to false, log defaults

### DIFF
--- a/src/build/credentials-command.ts
+++ b/src/build/credentials-command.ts
@@ -89,15 +89,21 @@ export async function saveCredentialsCommand(options: SaveCredentialsOptions): P
     const credentials: Partial<BuildCredentials> = {}
     const files: any = {}
 
-    const outputUploadEnabled = options.outputUpload === undefined
-      ? true
-      : parseOptionalBoolean(options.outputUpload)
-    const outputRetentionSeconds = options.outputRetention
-      ? parseOutputRetentionSeconds(options.outputRetention)
-      : MIN_OUTPUT_RETENTION_SECONDS
-
-    credentials.BUILD_OUTPUT_UPLOAD_ENABLED = outputUploadEnabled ? 'true' : 'false'
-    credentials.BUILD_OUTPUT_RETENTION_SECONDS = String(outputRetentionSeconds)
+    // Output upload settings: always save, inform user when defaulting
+    if (options.outputUpload !== undefined) {
+      credentials.BUILD_OUTPUT_UPLOAD_ENABLED = parseOptionalBoolean(options.outputUpload) ? 'true' : 'false'
+    }
+    else {
+      credentials.BUILD_OUTPUT_UPLOAD_ENABLED = 'false'
+      log.info('ℹ️  --output-upload not specified, defaulting to false (no Capgo download link)')
+    }
+    if (options.outputRetention) {
+      credentials.BUILD_OUTPUT_RETENTION_SECONDS = String(parseOutputRetentionSeconds(options.outputRetention))
+    }
+    else {
+      credentials.BUILD_OUTPUT_RETENTION_SECONDS = String(MIN_OUTPUT_RETENTION_SECONDS)
+      log.info(`ℹ️  --output-retention not specified, defaulting to ${MIN_OUTPUT_RETENTION_SECONDS}s (1 hour)`)
+    }
 
     if (platform === 'ios') {
       // Handle iOS credentials


### PR DESCRIPTION
## Summary
- Change BUILD_OUTPUT_UPLOAD_ENABLED default from true to false (opt-in, not opt-out)
- Log info messages when defaults are applied during credential save
- Fail early if no output destination (no play config + no output upload)

## Test plan
- [ ] Save android credentials without --output-upload: should default to false and log it
- [ ] Save android credentials with --output-upload: should save true, no extra log
- [ ] Save android credentials without --play-config and without --output-upload: should fail (no output destination)
- [ ] Save android credentials without --play-config but with --output-upload: should warn but succeed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced credential saving command with improved output option handling. The `--output-upload` and `--output-retention` flags now display informational messages indicating which default values are applied when options are omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->