### PR TITLE
fix: remove unused --build-config option

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -719,7 +719,6 @@ Example: npx @capgo/cli@latest build request com.example.app --platform ios --pa
   .option('--path <path>', `Path to the project directory to build (default: current directory)`)
   .option('--platform <platform>', `Target platform: ios or android (required)`)
   .option('--build-mode <buildMode>', `Build mode: debug or release (default: release)`)
-  .option('--build-config <buildConfig>', `Additional build configuration as JSON string`)
   // iOS credential CLI options (can also be set via env vars or saved credentials)
   .option('--build-certificate-base64 <cert>', 'iOS: Base64-encoded .p12 certificate')
   .option('--build-provision-profile-base64 <profile>', 'iOS: Base64-encoded provisioning profile')


### PR DESCRIPTION
## Summary

The `--build-config` CLI option was added to the `build request` command but was never implemented in the backend.

## Changes

- Removed the unused `--build-config <buildConfig>` option from the CLI

## Verification

- The option is not used in `src/build/request.ts`
- The option is not defined in `src/schemas/build.ts` (`buildRequestOptionsSchema`)
- A grep for `buildConfig` in the codebase only returns the CLI option definition

## Test Plan

- [ ] Run `npx @capgo/cli build request --help` and verify `--build-config` is no longer listed