### PR TITLE
refactor: remove legacy regex status detection from log stream

### DIFF
--- a/src/build/request.ts
+++ b/src/build/request.ts
@@ -184,15 +184,6 @@ async function streamBuildLogs(
     if (!message.trim())
       return
 
-    // Check for final status messages from the server
-    // Server sends "Build succeeded", "Build failed", "Job already succeeded", etc.
-    const statusMatch = message.match(/^(?:Build|Job already) (succeeded|failed|expired|released|cancelled)$/i)
-    if (statusMatch) {
-      finalStatus = statusMatch[1].toLowerCase()
-      // Don't display status messages as log lines - they'll be displayed as final status
-      return
-    }
-
     // Don't display logs after we've received a final status (e.g., cleanup messages after failure)
     if (finalStatus)
       return


### PR DESCRIPTION
## Summary

- Removes the regex that parsed plain-text log messages (`"Build succeeded"`, `"Build failed"`, etc.) for terminal status detection in `streamBuildLogs()`
- Status detection now relies solely on structured `{ type: 'status', status: '...' }` WebSocket messages from the scheduler, with `pollBuildStatus()` as fallback
- Plain-text status log lines now display normally to the user (useful since they include error reasons)

## Why

The regex was a legacy path from before the scheduler sent structured status messages. With the status simplification work on `capgo_builder`, the structured `{ type: 'status' }` message is the authoritative path. The regex was redundant and suppressed useful log output.

## Test plan

- [ ] Trigger a build that succeeds — verify CLI shows "Build completed successfully!"
- [ ] Trigger a build that fails — verify CLI shows the error log line AND "Build failed"
- [ ] Kill the WebSocket mid-build — verify `pollBuildStatus()` fallback still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified server status message handling in logs. Status indication messages will now appear in log output instead of being filtered, and status determination relies on alternative mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->