### PR TITLE
fix: add platform and build_mode to top-level request payload

### DIFF
--- a/src/build/request.ts
+++ b/src/build/request.ts
@@ -1200,6 +1200,8 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
 
     const requestPayload = {
       app_id: appId,
+      platform: options.platform,
+      build_mode: options.buildMode || 'release',
       build_options: buildOptionsPayload,
       build_credentials: buildCredentialsPayload,
     }


### PR DESCRIPTION
## Summary
- Adds `platform` and `build_mode` to the top-level request payload sent to `POST /build/request`
- The capgo proxy validates `platform` at the root level before forwarding to the builder — without this the API returns `"platform is required"`

## Test plan
- [ ] Run `npx @capgo/cli build --platform android` and confirm the request includes top-level `platform`
- [ ] Verify the proxy no longer returns "platform is required"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build requests now include platform information and configurable build mode settings, with 'release' as the default build mode when not explicitly specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->