### PR TITLE
Improve CLI error handling and debug network messages

### DIFF
--- a/src/app/add.ts
+++ b/src/app/add.ts
@@ -142,8 +142,6 @@ export async function addAppInternal(
 
     if (error) {
       if (!silent)
-        console.error(error)
-      if (!silent)
         log.error(`Could not add app ${formatError(error)}`)
       throw new Error(`Could not add app ${formatError(error)}`)
     }

--- a/src/app/debug.ts
+++ b/src/app/debug.ts
@@ -18,6 +18,40 @@ function formatTimeOnly(createdAt: string) {
   return d.toLocaleTimeString()
 }
 
+function describeFetchFailure(error: unknown, endpoint: string) {
+  const details = error as {
+    message?: string
+    name?: string
+    cause?: {
+      message?: string
+      name?: string
+      code?: string
+    }
+    code?: string
+  }
+
+  const causeName = details?.cause?.name
+  const causeCode = details?.cause?.code || details?.code
+  const message = (details?.message || '').toLowerCase()
+
+  if (causeCode === 'UND_ERR_CONNECT_TIMEOUT'
+    || causeName === 'UND_ERR_CONNECT_TIMEOUT'
+    || /connect timeout/.test(message)
+    || /timed out/.test(message)) {
+    return `Cannot reach ${endpoint} (connection timeout after 10s). Check VPN/firewall/network rules or update API host settings in capacitor.config.json.`
+  }
+
+  if (causeCode === 'ENOTFOUND' || causeCode === 'ECONNREFUSED' || message.includes('fetch failed')) {
+    return `Cannot reach ${endpoint} (network error). Verify internet connectivity and that ${endpoint} is reachable from this machine.`
+  }
+
+  if (message.startsWith('http error! status: ')) {
+    return details?.message || 'Capgo API returned an HTTP error.'
+  }
+
+  return formatError(error)
+}
+
 export type { AppDebugOptions as OptionsBaseDebug } from '../schemas/app'
 
 export async function markSnag(channel: string, orgId: string, apikey: string, event: string, appId?: string, icon = '✅') {
@@ -62,12 +96,14 @@ interface LogData {
   created_at: string
 }
 export async function getStats(apikey: string, query: QueryStats, after: string | null): Promise<LogData[]> {
+  const localConfig = await getLocalConfig()
+  const statsEndpoint = `${localConfig.hostApi}/private/stats`
+
   try {
-    const localConfig = await getLocalConfig()
     // If we already have a latest timestamp, query only after that point
     const effectiveQuery: QueryStats = after ? { ...query, rangeStart: after } : { ...query }
 
-    const response = await fetch(`${localConfig.hostApi}/private/stats`, {
+    const response = await fetch(statsEndpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -86,8 +122,7 @@ export async function getStats(apikey: string, query: QueryStats, after: string 
       return dataD
   }
   catch (error) {
-    console.error('Cannot get devices', error)
-    log.error(`Cannot get stats ${formatError(error)}`)
+    log.error(`Cannot get stats: ${describeFetchFailure(error, statsEndpoint)}`)
   }
   return []
 }

--- a/src/docs.ts
+++ b/src/docs.ts
@@ -2,6 +2,7 @@ import type { Command, Option } from 'commander'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { log } from '@clack/prompts'
 import { program } from 'commander'
+import { formatError } from './utils'
 
 // Define proper types for mapped commands
 interface CommandOption {
@@ -261,7 +262,7 @@ sidebar:
         log.success(`Generated documentation file for ${cmd.name} command in ${folderPath}/${cmd.name}.mdx`)
       }
       catch (error) {
-        console.error(`Error generating file for ${cmd.name}:`, error)
+        log.error(`Error generating file for ${cmd.name}: ${formatError(error)}`)
       }
     }
     log.success(`Documentation files generated in ${folderPath}/`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { exit } from 'node:process'
 import { Option, program } from 'commander'
+import { log } from '@clack/prompts'
 import pack from '../package.json'
 import { addApp } from './app/add'
 import { debugApp } from './app/debug'
@@ -979,12 +980,12 @@ program.parseAsync().catch((error: unknown) => {
     }
     // For actual errors, show just the message without the full stack trace
     if (commanderError.message) {
-      console.error(commanderError.message)
+      log.error(commanderError.message)
     }
     const exitCode = commanderError.exitCode ?? 1
     exit(exitCode)
   }
   // For non-Commander errors, show full error details
-  console.error(`Error: ${formatError(error)}`)
+  log.error(`Error: ${formatError(error)}`)
   exit(1)
 })

--- a/src/init.ts
+++ b/src/init.ts
@@ -17,7 +17,7 @@ import { addChannelInternal } from './channel/add'
 import { createKeyInternal } from './key'
 import { doLoginExists, loginInternal } from './login'
 import { showReplicationProgress } from './replicationProgress'
-import { createSupabaseClient, findBuildCommandForProjectType, findMainFile, findMainFileForProjectType, findProjectType, findRoot, findSavedKey, getAllPackagesDependencies, getAppId, getBundleVersion, getConfig, getInstalledVersion, getLocalConfig, getOrganization, getPackageScripts, getPMAndCommand, PACKNAME, projectIsMonorepo, updateConfigbyKey, updateConfigUpdater, validateIosUpdaterSync, verifyUser } from './utils'
+import { createSupabaseClient, findBuildCommandForProjectType, findMainFile, findMainFileForProjectType, findProjectType, findRoot, findSavedKey, formatError, getAllPackagesDependencies, getAppId, getBundleVersion, getConfig, getInstalledVersion, getLocalConfig, getOrganization, getPackageScripts, getPMAndCommand, PACKNAME, projectIsMonorepo, updateConfigbyKey, updateConfigUpdater, validateIosUpdaterSync, verifyUser } from './utils'
 
 interface SuperOptions extends Options {
   local: boolean
@@ -1418,7 +1418,7 @@ export async function initApp(apikeyCommand: string, appId: string, options: Sup
     cleanupStepsDone()
   }
   catch (e) {
-    console.error(e)
+    pLog.error(`Error during onboarding: ${formatError(e)}`)
     pLog.error(`Error during onboarding.\n if the error persists please contact support@capgo.app\n Or use manual installation: https://capgo.app/docs/getting-started/add-an-app/`)
     exit(1)
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,13 +54,62 @@ export const regexSemver = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[
  */
 export function formatError(error: any): string {
   if (!error)
-    return ''
+    return 'Unknown error'
 
   // Check if this is a security policy error first
   const parsed = parseSecurityPolicyError(error)
   if (parsed.isSecurityPolicyError) {
     return formatApiErrorForCli(error)
   }
+
+  const asError = error as {
+    message?: string
+    stack?: string
+    cause?: { message?: string, name?: string }
+    code?: string | number
+    status?: number
+    statusCode?: number
+    details?: string
+    hint?: string
+    error?: string | { message?: string }
+  }
+
+  if (typeof error === 'string')
+    return error
+
+  if (error instanceof Error) {
+    const reason = asError.message || asError.cause?.message || asError.stack || error.name
+    const causeName = asError.cause?.name
+    const reasonLower = reason.toLowerCase()
+    if (reasonLower.includes('fetch failed') || reasonLower.includes('failed to fetch') || reasonLower.includes('connect timeout')
+      || reasonLower.includes('network') || causeName?.startsWith('UND_ERR')) {
+      return `Network error: ${reason}${asError.code ? ` (code ${asError.code})` : ''}. Check your network connection and API endpoint availability.`
+    }
+
+    const status = asError.status || asError.statusCode
+    const details = [reason, asError.code ? `Code: ${asError.code}` : undefined, status ? `Status: ${status}` : undefined]
+      .filter(Boolean)
+      .join(' | ')
+    return details || error.name
+  }
+
+  if (asError.message) {
+    const details = [asError.message, asError.code ? `Code: ${asError.code}` : undefined, asError.status || asError.statusCode ? `Status: ${asError.status || asError.statusCode}` : undefined]
+      .filter(Boolean)
+      .join(' | ')
+    const normalized = asError.message.toLowerCase()
+    if (normalized.includes('fetch failed') || normalized.includes('failed to fetch') || asError.error === 'Failed to fetch') {
+      return `Network error: ${details}. Check your network connection and API endpoint availability.`
+    }
+    if (asError.details || asError.hint || asError.error)
+      return `${details}${details ? ' | ' : ''}${asError.error ? (typeof asError.error === 'string' ? asError.error : asError.error.message ?? '') : ''}${asError.details ? `Details: ${asError.details}` : ''}${asError.hint ? `Hint: ${asError.hint}` : ''}`.trim()
+    return details
+  }
+
+  if (typeof asError.error === 'string' && asError.error.length > 0)
+    return asError.error
+  if (asError.error && typeof asError.error === 'object' && typeof asError.error.message === 'string' && asError.error.message.length > 0)
+    return asError.error.message
 
   // Fall back to prettyjson for other errors
   return `\n${prettyjson.render(error)}`
@@ -647,7 +696,7 @@ export async function isAllowedAppOrg(supabase: SupabaseClient<Database>, apikey
 
   if (error) {
     log.error('Cannot get permissions for organization!')
-    console.error(error)
+    log.error(formatError(error))
     throw new Error('Cannot get permissions for organization')
   }
 
@@ -1648,7 +1697,7 @@ export async function getLocalDependencies(packageJsonPath: string | undefined, 
   }
   catch (err) {
     log.error('Invalid package.json, JSON parsing failed')
-    console.error('json parse error: ', err)
+    log.error(`json parse error: ${formatError(err)}`)
     throw err instanceof Error ? err : new Error('Invalid package.json')
   }
   const firstPackageJson = packageJsonPath
@@ -1715,7 +1764,7 @@ export async function getLocalDependencies(packageJsonPath: string | undefined, 
           }
           catch (error) {
             log.error(`Error reading node_modules files for ${key} package in ${modulePath}`)
-            console.error(error)
+            log.error(formatError(error))
             throw error instanceof Error ? error : new Error(`Error reading node_modules files for ${key}`)
           }
         }


### PR DESCRIPTION
This PR improves user-facing error reporting across the CLI by replacing raw console error dumps with formatted, actionable messages. It adds network-specific diagnostics for `app debug` stats polling, including timeout and connectivity guidance with endpoint context. It also routes top-level command and onboarding failures through consistent `@clack/prompts` error output. Finally, it centralizes error normalization in `formatError` and updates several high-noise paths to use that formatter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message formatting to provide clearer, more user-friendly feedback across all failure scenarios.
  * Enhanced network error detection and reporting to better guide users when connection issues occur.
  * Standardized error logging mechanisms throughout the application for consistent error communication.
  * Strengthened error handling in data parsing and fetch operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->