### PR TITLE
feat: migrate CLI auth checks to RBAC-aware permissions

### DIFF
--- a/src/app/add.ts
+++ b/src/app/add.ts
@@ -91,16 +91,16 @@ export async function addAppInternal(
   ensureOptions(appId, options, silent)
 
   const supabase = await createSupabaseClient(options.apikey!, options.supaHost, options.supaAnon)
-  const userId = await resolveUserIdFromApiKey(supabase, options.apikey!)
+  const userId = await resolveUserIdFromApiKey(supabase, options.apikey)
 
   await ensureAppDoesNotExist(supabase, appId, silent)
 
   if (!organization)
-    organization = await getOrganizationWithPermission(supabase, options.apikey!, 'org.create_app')
+    organization = await getOrganizationWithPermission(supabase, options.apikey, 'org.create_app')
 
   const organizationUid = organization.gid
 
-  await assertCliPermission(supabase, options.apikey!, 'org.create_app', { orgId: organizationUid }, {
+  await assertCliPermission(supabase, options.apikey, 'org.create_app', { orgId: organizationUid }, {
     message: `Insufficient permissions to create an app in organization ${organizationUid}`,
     silent,
   })

--- a/src/app/add.ts
+++ b/src/app/add.ts
@@ -8,15 +8,16 @@ import { intro, log, outro } from '@clack/prompts'
 import { checkAppExists, defaultAppIconPath, getAppIconStoragePath, newIconPath } from '../api/app'
 import { checkAlerts } from '../api/update'
 import {
+  assertCliPermission,
   createSupabaseClient,
   findSavedKey,
   formatError,
   getAppId,
   getConfig,
   getContentType,
-  getOrganization,
+  getOrganizationWithPermission,
+  resolveUserIdFromApiKey,
   sendEvent,
-  verifyUser,
 } from '../utils'
 
 export const reverseDomainRegex = /^[a-z0-9]+(\.[\w-]+)+$/i
@@ -90,14 +91,19 @@ export async function addAppInternal(
   ensureOptions(appId, options, silent)
 
   const supabase = await createSupabaseClient(options.apikey!, options.supaHost, options.supaAnon)
-  const userId = await verifyUser(supabase, options.apikey!, ['write', 'all'])
+  const userId = await resolveUserIdFromApiKey(supabase, options.apikey!)
 
   await ensureAppDoesNotExist(supabase, appId, silent)
 
   if (!organization)
-    organization = await getOrganization(supabase, ['admin', 'super_admin'])
+    organization = await getOrganizationWithPermission(supabase, options.apikey!, 'org.create_app')
 
   const organizationUid = organization.gid
+
+  await assertCliPermission(supabase, options.apikey!, 'org.create_app', { orgId: organizationUid }, {
+    message: `Insufficient permissions to create an app in organization ${organizationUid}`,
+    silent,
+  })
 
   let { name, icon } = options
   name = name || extConfig.config?.appName || 'Unknown'

--- a/src/app/delete.ts
+++ b/src/app/delete.ts
@@ -9,8 +9,8 @@ import {
   getConfig,
   getOrganizationId,
   OrganizationPerm,
+  resolveUserIdFromApiKey,
   sendEvent,
-  verifyUser,
 } from '../utils'
 
 export async function deleteAppInternal(
@@ -39,7 +39,7 @@ export async function deleteAppInternal(
   }
 
   const supabase = await createSupabaseClient(options.apikey, options.supaHost, options.supaAnon)
-  const userId = await verifyUser(supabase, options.apikey, ['write', 'all'])
+  const userId = await resolveUserIdFromApiKey(supabase, options.apikey)
 
   await checkAppExistsAndHasPermissionOrgErr(supabase, options.apikey, appId, OrganizationPerm.super_admin, silent)
 

--- a/src/app/list.ts
+++ b/src/app/list.ts
@@ -4,7 +4,7 @@ import type { Database } from '../types/supabase.types'
 import { intro, log, outro } from '@clack/prompts'
 import { Table } from '@sauber/table'
 import { checkAlerts } from '../api/update'
-import { createSupabaseClient, findSavedKey, getHumanDate, verifyUser } from '../utils'
+import { createSupabaseClient, findSavedKey, getAccessibleAppsForApiKey, getHumanDate, resolveUserIdFromApiKey } from '../utils'
 
 function displayApps(data: Database['public']['Tables']['apps']['Row'][]) {
   const table = new Table()
@@ -18,22 +18,8 @@ function displayApps(data: Database['public']['Tables']['apps']['Row'][]) {
   log.success(table.toString())
 }
 
-async function getActiveApps(
-  supabase: SupabaseClient<Database>,
-  silent: boolean,
-) {
-  const { data, error: vError } = await supabase
-    .from('apps')
-    .select()
-    .order('created_at', { ascending: false })
-
-  if (vError) {
-    if (!silent)
-      log.error('Apps not found')
-    throw new Error('Apps not found')
-  }
-
-  return data ?? []
+async function getActiveApps(supabase: SupabaseClient<Database>, apikey: string) {
+  return getAccessibleAppsForApiKey(supabase, apikey)
 }
 
 export async function listAppInternal(options: OptionsBase, silent = false) {
@@ -46,12 +32,12 @@ export async function listAppInternal(options: OptionsBase, silent = false) {
 
   const supabase = await createSupabaseClient(options.apikey, options.supaHost, options.supaAnon)
 
-  await verifyUser(supabase, options.apikey, ['write', 'all', 'read', 'upload'])
+  await resolveUserIdFromApiKey(supabase, options.apikey)
 
   if (!silent)
     log.info('Getting active bundle in Capgo')
 
-  const allApps = await getActiveApps(supabase, silent)
+  const allApps = await getActiveApps(supabase, options.apikey)
 
   if (!allApps.length) {
     if (!silent)

--- a/src/app/list.ts
+++ b/src/app/list.ts
@@ -4,7 +4,7 @@ import type { Database } from '../types/supabase.types'
 import { intro, log, outro } from '@clack/prompts'
 import { Table } from '@sauber/table'
 import { checkAlerts } from '../api/update'
-import { createSupabaseClient, findSavedKey, getAccessibleAppsForApiKey, getHumanDate, resolveUserIdFromApiKey } from '../utils'
+import { createSupabaseClient, findSavedKey, getHumanDate, resolveUserIdFromApiKey } from '../utils'
 
 function displayApps(data: Database['public']['Tables']['apps']['Row'][]) {
   const table = new Table()
@@ -18,8 +18,19 @@ function displayApps(data: Database['public']['Tables']['apps']['Row'][]) {
   log.success(table.toString())
 }
 
-async function getActiveApps(supabase: SupabaseClient<Database>, apikey: string) {
-  return getAccessibleAppsForApiKey(supabase, apikey)
+async function getActiveApps(supabase: SupabaseClient<Database>, silent: boolean) {
+  const { data, error } = await supabase
+    .from('apps')
+    .select()
+    .order('created_at', { ascending: false })
+
+  if (error) {
+    if (!silent)
+      log.error('Apps not found')
+    throw new Error('Apps not found')
+  }
+
+  return data ?? []
 }
 
 export async function listAppInternal(options: OptionsBase, silent = false) {
@@ -37,7 +48,7 @@ export async function listAppInternal(options: OptionsBase, silent = false) {
   if (!silent)
     log.info('Getting active bundle in Capgo')
 
-  const allApps = await getActiveApps(supabase, options.apikey)
+  const allApps = await getActiveApps(supabase, silent)
 
   if (!allApps.length) {
     if (!silent)

--- a/src/app/set.ts
+++ b/src/app/set.ts
@@ -10,10 +10,9 @@ import {
   getAppId,
   getConfig,
   getContentType,
-  getOrganization,
+  getOrganizationId,
   OrganizationPerm,
   sendEvent,
-  verifyUser,
 } from '../utils'
 
 export async function setAppInternal(appId: string, options: Options, silent = false) {
@@ -37,12 +36,8 @@ export async function setAppInternal(appId: string, options: Options, silent = f
   }
 
   const supabase = await createSupabaseClient(options.apikey, options.supaHost, options.supaAnon)
-  const organization = await getOrganization(supabase, ['admin', 'super_admin'])
-  const organizationUid = organization.gid
-
-  const userId = await verifyUser(supabase, options.apikey, ['write', 'all'])
-
   await checkAppExistsAndHasPermissionOrgErr(supabase, options.apikey, appId, OrganizationPerm.admin, silent)
+  const organizationUid = await getOrganizationId(supabase, appId)
 
   const { name, icon, retention, exposeMetadata } = options
 
@@ -111,7 +106,6 @@ export async function setAppInternal(appId: string, options: Options, silent = f
       expose_metadata: exposeMetadata,
     })
     .eq('app_id', appId)
-    .eq('user_id', userId)
 
   if (dbError) {
     if (!silent)

--- a/src/build/request.ts
+++ b/src/build/request.ts
@@ -263,6 +263,13 @@ function decodeEventData(event: MessageEvent): string {
   return ''
 }
 
+function warnOrLog(message: string, logger: BuildLogger | undefined, silent: boolean): void {
+  if (logger)
+    logger.warn(message)
+  else if (!silent)
+    clackLog.warn(message)
+}
+
 async function dispatchCustomMsg(
   kind: string,
   data: Record<string, unknown>,
@@ -284,10 +291,7 @@ async function dispatchCustomMsg(
     }
   }
   catch (error) {
-    if (logger)
-      logger.warn(`Custom message handler encountered an error, continuing... ${String(error)}`)
-    else if (!silent)
-      clackLog.warn(`Custom message handler encountered an error, continuing... ${String(error)}`)
+    warnOrLog(`Custom message handler encountered an error, continuing... ${String(error)}`, logger, silent)
   }
 }
 
@@ -489,10 +493,7 @@ async function streamBuildLogs(
           ws.send(JSON.stringify({ type: 'confirmed_received', lastId: id }))
         }
         catch (error) {
-          if (logger)
-            logger.warn(`Failed to send log confirmation, continuing... ${String(error)}`)
-          else if (!silent)
-            clackLog.warn(`Failed to send log confirmation, continuing... ${String(error)}`)
+          warnOrLog(`Failed to send log confirmation, continuing... ${String(error)}`, logger, silent)
         }
       }
 

--- a/src/build/request.ts
+++ b/src/build/request.ts
@@ -1066,7 +1066,7 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
     const host = options.supaHost || 'https://api.capgo.app'
 
     const supabase = await createSupabaseClient(options.apikey, options.supaHost, options.supaAnon)
-    await resolveUserIdFromApiKey(supabase, options.apikey)
+    await resolveUserIdFromApiKey(supabase, options.apikey, silent)
     await assertCliPermission(supabase, options.apikey, 'app.build_native', { appId }, {
       message: `Insufficient permissions to request a native build for app ${appId}`,
       silent,

--- a/src/build/request.ts
+++ b/src/build/request.ts
@@ -237,9 +237,31 @@ export type { BuildCredentials, BuildRequestOptions, BuildRequestResponse, Build
  * Returns the final status if detected from the stream, or null if stream ended without status.
  */
 type StatusCheckFn = () => Promise<string | null>
+type WsEntry = {
+  id?: number
+  message?: string
+  type?: string
+  status?: string
+  kind?: string
+  data?: Record<string, unknown>
+}
 
 const TERMINAL_STATUSES = ['succeeded', 'failed', 'expired', 'released', 'cancelled'] as const
 const TERMINAL_STATUS_SET = new Set<string>(TERMINAL_STATUSES)
+
+function decodeEventData(event: MessageEvent): string {
+  if (typeof event.data === 'string')
+    return event.data
+  if (event.data instanceof ArrayBuffer)
+    return new TextDecoder().decode(event.data)
+  if (ArrayBuffer.isView(event.data)) {
+    const view = event.data as ArrayBufferView
+    return new TextDecoder().decode(new Uint8Array(view.buffer, view.byteOffset, view.byteLength))
+  }
+  if (event.data && typeof (event.data as { toString?: () => string }).toString === 'function')
+    return (event.data as { toString: () => string }).toString()
+  return ''
+}
 
 async function streamBuildLogs(
   silent: boolean,
@@ -408,6 +430,55 @@ async function streamBuildLogs(
         }, HEARTBEAT_INTERVAL_MS)
       }
 
+      const handleEntry = async (entry: WsEntry) => {
+        if (entry.type === 'custom_msg' && typeof entry.kind === 'string' && entry.data) {
+          lastMessageAt = Date.now()
+          if (logger) {
+            await logger.customMsg(entry.kind, entry.data)
+          }
+          else if (!silent) {
+            await handleCustomMsg(
+              entry.kind,
+              entry.data,
+              // eslint-disable-next-line no-console
+              (line: string) => console.log(line),
+              (line: string) => clackLog.warn(line),
+            )
+          }
+          return
+        }
+        if (entry.type === 'status' && typeof entry.status === 'string') {
+          const status = entry.status.toLowerCase()
+          lastMessageAt = Date.now()
+          if (terminalStatuses.has(status))
+            finalStatus = status
+          return
+        }
+        if (entry.type === 'log' && typeof entry.message === 'string') {
+          lastMessageAt = Date.now()
+          processLogMessage(entry.message)
+          return
+        }
+        if (typeof entry.message === 'string') {
+          lastMessageAt = Date.now()
+          processLogMessage(entry.message)
+        }
+      }
+
+      const sendConfirmation = (id: number) => {
+        if (ws.readyState !== PartySocket.OPEN)
+          return
+        try {
+          ws.send(JSON.stringify({ type: 'confirmed_received', lastId: id }))
+        }
+        catch (error) {
+          if (logger)
+            logger.warn(`Failed to send log confirmation, continuing... ${String(error)}`)
+          else if (!silent)
+            clackLog.warn(`Failed to send log confirmation, continuing... ${String(error)}`)
+        }
+      }
+
       startHeartbeat()
 
       if (abortSignal) {
@@ -423,30 +494,9 @@ async function streamBuildLogs(
       }
 
       ws.addEventListener('message', async (event: MessageEvent) => {
-        let raw = ''
-        if (typeof event.data === 'string') {
-          raw = event.data
-        }
-        else if (event.data instanceof ArrayBuffer) {
-          raw = new TextDecoder().decode(event.data)
-        }
-        else if (ArrayBuffer.isView(event.data)) {
-          const view = event.data as ArrayBufferView
-          raw = new TextDecoder().decode(new Uint8Array(view.buffer, view.byteOffset, view.byteLength))
-        }
-        else if (event.data && typeof (event.data as { toString?: () => string }).toString === 'function') {
-          raw = (event.data as { toString: () => string }).toString()
-        }
+        const raw = decodeEventData(event)
 
-        let parsed: {
-          id?: number
-          message?: string
-          type?: string
-          status?: string
-          kind?: string
-          data?: Record<string, unknown>
-          messages?: Array<{ id?: number, message?: string, type?: string, status?: string, kind?: string, data?: Record<string, unknown> }>
-        } | null = null
+        let parsed: (WsEntry & { messages?: WsEntry[] }) | null = null
         try {
           parsed = JSON.parse(raw)
         }
@@ -454,45 +504,8 @@ async function streamBuildLogs(
           parsed = null
         }
 
-        const handleEntry = async (entry: { id?: number, message?: string, type?: string, status?: string, kind?: string, data?: Record<string, unknown> }) => {
-          if (entry.type === 'custom_msg' && typeof entry.kind === 'string' && entry.data) {
-            lastMessageAt = Date.now()
-            if (logger) {
-              await logger.customMsg(entry.kind, entry.data)
-            }
-            else if (!silent) {
-              await handleCustomMsg(
-                entry.kind,
-                entry.data,
-                // eslint-disable-next-line no-console
-                (line: string) => console.log(line),
-                (line: string) => clackLog.warn(line),
-              )
-            }
-            return
-          }
-          if (entry.type === 'status' && typeof entry.status === 'string') {
-            const status = entry.status.toLowerCase()
-            lastMessageAt = Date.now()
-            if (terminalStatuses.has(status)) {
-              finalStatus = status
-            }
-            return
-          }
-          if (entry.type === 'log' && typeof entry.message === 'string') {
-            lastMessageAt = Date.now()
-            processLogMessage(entry.message)
-            return
-          }
-          if (typeof entry.message === 'string') {
-            lastMessageAt = Date.now()
-            processLogMessage(entry.message)
-          }
-        }
-
-        if (parsed?.type === 'heartbeat_response') {
+        if (parsed?.type === 'heartbeat_response')
           return
-        }
 
         if (parsed?.type === 'batch_messages' && Array.isArray(parsed.messages)) {
           let maxId = lastConfirmedId
@@ -503,23 +516,12 @@ async function streamBuildLogs(
           }
           if (maxId > lastConfirmedId) {
             lastConfirmedId = maxId
-            if (ws.readyState === PartySocket.OPEN) {
-              try {
-                ws.send(JSON.stringify({ type: 'confirmed_received', lastId: maxId }))
-              }
-              catch (error) {
-                if (logger)
-                  logger.warn(`Failed to send log confirmation, continuing... ${String(error)}`)
-                else if (!silent)
-                  clackLog.warn(`Failed to send log confirmation, continuing... ${String(error)}`)
-              }
-            }
+            sendConfirmation(maxId)
           }
         }
         else {
-          if (parsed) {
+          if (parsed)
             await handleEntry(parsed)
-          }
           else if (raw) {
             lastMessageAt = Date.now()
             processLogMessage(raw)
@@ -527,23 +529,12 @@ async function streamBuildLogs(
 
           if (parsed && typeof parsed.id === 'number') {
             lastConfirmedId = parsed.id
-            if (ws.readyState === PartySocket.OPEN) {
-              try {
-                ws.send(JSON.stringify({ type: 'confirmed_received', lastId: parsed.id }))
-              }
-              catch (error) {
-                if (logger)
-                  logger.warn(`Failed to send log confirmation, continuing... ${String(error)}`)
-                else if (!silent)
-                  clackLog.warn(`Failed to send log confirmation, continuing... ${String(error)}`)
-              }
-            }
+            sendConfirmation(parsed.id)
           }
         }
 
-        if (finalStatus) {
+        if (finalStatus)
           finish(finalStatus)
-        }
       })
 
       ws.addEventListener('error', () => {

--- a/src/build/request.ts
+++ b/src/build/request.ts
@@ -237,7 +237,7 @@ export type { BuildCredentials, BuildRequestOptions, BuildRequestResponse, Build
  * Returns the final status if detected from the stream, or null if stream ended without status.
  */
 type StatusCheckFn = () => Promise<string | null>
-type WsEntry = {
+interface WsEntry {
   id?: number
   message?: string
   type?: string
@@ -520,8 +520,9 @@ async function streamBuildLogs(
           }
         }
         else {
-          if (parsed)
+          if (parsed) {
             await handleEntry(parsed)
+          }
           else if (raw) {
             lastMessageAt = Date.now()
             processLogMessage(raw)

--- a/src/build/request.ts
+++ b/src/build/request.ts
@@ -39,7 +39,7 @@ import { WebSocket as PartySocket } from 'partysocket'
 import * as tus from 'tus-js-client'
 import WS from 'ws' // TODO: remove when min version nodejs 22 is bump, should do it in july 2026 as it become deprecated
 import pack from '../../package.json'
-import { createSupabaseClient, findSavedKey, getConfig, getOrganizationId, sendEvent, verifyUser } from '../utils'
+import { assertCliPermission, createSupabaseClient, findSavedKey, getConfig, getOrganizationId, resolveUserIdFromApiKey, sendEvent } from '../utils'
 import { mergeCredentials, MIN_OUTPUT_RETENTION_SECONDS, parseOptionalBoolean, parseOutputRetentionSeconds } from './credentials'
 import { buildProvisioningMap } from './credentials-command'
 import { getPlatformDirFromCapacitorConfig } from './platform-paths'
@@ -1066,7 +1066,11 @@ export async function requestBuildInternal(appId: string, options: BuildRequestO
     const host = options.supaHost || 'https://api.capgo.app'
 
     const supabase = await createSupabaseClient(options.apikey, options.supaHost, options.supaAnon)
-    await verifyUser(supabase, options.apikey, ['write', 'all'])
+    await resolveUserIdFromApiKey(supabase, options.apikey)
+    await assertCliPermission(supabase, options.apikey, 'app.build_native', { appId }, {
+      message: `Insufficient permissions to request a native build for app ${appId}`,
+      silent,
+    })
 
     // Get organization ID for analytics
     const orgId = await getOrganizationId(supabase, appId)

--- a/src/build/request.ts
+++ b/src/build/request.ts
@@ -263,6 +263,34 @@ function decodeEventData(event: MessageEvent): string {
   return ''
 }
 
+async function dispatchCustomMsg(
+  kind: string,
+  data: Record<string, unknown>,
+  logger: BuildLogger | undefined,
+  silent: boolean,
+): Promise<void> {
+  try {
+    if (logger) {
+      await logger.customMsg(kind, data)
+    }
+    else if (!silent) {
+      await handleCustomMsg(
+        kind,
+        data,
+        // eslint-disable-next-line no-console
+        (line: string) => console.log(line),
+        (line: string) => clackLog.warn(line),
+      )
+    }
+  }
+  catch (error) {
+    if (logger)
+      logger.warn(`Custom message handler encountered an error, continuing... ${String(error)}`)
+    else if (!silent)
+      clackLog.warn(`Custom message handler encountered an error, continuing... ${String(error)}`)
+  }
+}
+
 async function streamBuildLogs(
   silent: boolean,
   _verbose = false,
@@ -433,26 +461,7 @@ async function streamBuildLogs(
       const handleEntry = async (entry: WsEntry) => {
         if (entry.type === 'custom_msg' && typeof entry.kind === 'string' && entry.data) {
           lastMessageAt = Date.now()
-          try {
-            if (logger) {
-              await logger.customMsg(entry.kind, entry.data)
-            }
-            else if (!silent) {
-              await handleCustomMsg(
-                entry.kind,
-                entry.data,
-                // eslint-disable-next-line no-console
-                (line: string) => console.log(line),
-                (line: string) => clackLog.warn(line),
-              )
-            }
-          }
-          catch (error) {
-            if (logger)
-              logger.warn(`Custom message handler encountered an error, continuing... ${String(error)}`)
-            else if (!silent)
-              clackLog.warn(`Custom message handler encountered an error, continuing... ${String(error)}`)
-          }
+          await dispatchCustomMsg(entry.kind, entry.data, logger, silent)
           return
         }
         if (entry.type === 'status' && typeof entry.status === 'string') {

--- a/src/build/request.ts
+++ b/src/build/request.ts
@@ -536,7 +536,7 @@ async function streamBuildLogs(
             processLogMessage(raw)
           }
 
-          if (parsed && typeof parsed.id === 'number') {
+          if (parsed && typeof parsed.id === 'number' && parsed.id > lastConfirmedId) {
             lastConfirmedId = parsed.id
             sendConfirmation(parsed.id)
           }

--- a/src/build/request.ts
+++ b/src/build/request.ts
@@ -433,17 +433,25 @@ async function streamBuildLogs(
       const handleEntry = async (entry: WsEntry) => {
         if (entry.type === 'custom_msg' && typeof entry.kind === 'string' && entry.data) {
           lastMessageAt = Date.now()
-          if (logger) {
-            await logger.customMsg(entry.kind, entry.data)
+          try {
+            if (logger) {
+              await logger.customMsg(entry.kind, entry.data)
+            }
+            else if (!silent) {
+              await handleCustomMsg(
+                entry.kind,
+                entry.data,
+                // eslint-disable-next-line no-console
+                (line: string) => console.log(line),
+                (line: string) => clackLog.warn(line),
+              )
+            }
           }
-          else if (!silent) {
-            await handleCustomMsg(
-              entry.kind,
-              entry.data,
-              // eslint-disable-next-line no-console
-              (line: string) => console.log(line),
-              (line: string) => clackLog.warn(line),
-            )
+          catch (error) {
+            if (logger)
+              logger.warn(`Custom message handler encountered an error, continuing... ${String(error)}`)
+            else if (!silent)
+              clackLog.warn(`Custom message handler encountered an error, continuing... ${String(error)}`)
           }
           return
         }

--- a/src/bundle/cleanup.ts
+++ b/src/bundle/cleanup.ts
@@ -20,7 +20,7 @@ import {
   getConfig,
   getHumanDate,
   OrganizationPerm,
-  verifyUser,
+  resolveUserIdFromApiKey,
 } from '../utils'
 
 async function removeVersions(
@@ -80,7 +80,7 @@ export async function cleanupBundleInternal(appId: string, options: BundleCleanu
 
   const supabase = await createSupabaseClient(options.apikey, options.supaHost, options.supaAnon)
   await check2FAComplianceForApp(supabase, appId, silent)
-  await verifyUser(supabase, options.apikey, ['write', 'all'])
+  await resolveUserIdFromApiKey(supabase, options.apikey)
   await checkAppExistsAndHasPermissionOrgErr(supabase, options.apikey, appId, OrganizationPerm.write, silent, true)
 
   if (!silent)

--- a/src/bundle/compatibility.ts
+++ b/src/bundle/compatibility.ts
@@ -13,7 +13,7 @@ import {
   getConfig,
   isCompatible,
   OrganizationPerm,
-  verifyUser,
+  resolveUserIdFromApiKey,
 } from '../utils'
 
 interface CompatibilityResult {
@@ -64,7 +64,7 @@ export async function checkCompatibilityInternal(
     enrichedOptions.supaAnon,
   )
   await check2FAComplianceForApp(supabase, resolvedAppId, silent)
-  await verifyUser(supabase, enrichedOptions.apikey, ['write', 'all', 'read', 'upload'])
+  await resolveUserIdFromApiKey(supabase, enrichedOptions.apikey)
   await checkAppExistsAndHasPermissionOrgErr(
     supabase,
     enrichedOptions.apikey,

--- a/src/bundle/delete.ts
+++ b/src/bundle/delete.ts
@@ -2,7 +2,7 @@ import type { BundleDeleteOptions } from '../schemas/bundle'
 import { intro, log, outro } from '@clack/prompts'
 import { check2FAComplianceForApp, checkAppExistsAndHasPermissionOrgErr } from '../api/app'
 import { deleteSpecificVersion } from '../api/versions'
-import { createSupabaseClient, findSavedKey, getAppId, getConfig, getOrganizationId, OrganizationPerm, sendEvent, verifyUser } from '../utils'
+import { createSupabaseClient, findSavedKey, getAppId, getConfig, getOrganizationId, OrganizationPerm, resolveUserIdFromApiKey, sendEvent } from '../utils'
 
 export async function deleteBundleInternal(bundleId: string, appId: string, options: BundleDeleteOptions, silent = false) {
   if (!silent)
@@ -32,7 +32,7 @@ export async function deleteBundleInternal(bundleId: string, appId: string, opti
 
   const supabase = await createSupabaseClient(options.apikey, options.supaHost, options.supaAnon)
   await check2FAComplianceForApp(supabase, appId, silent)
-  await verifyUser(supabase, options.apikey, ['write', 'all'])
+  await resolveUserIdFromApiKey(supabase, options.apikey)
   await checkAppExistsAndHasPermissionOrgErr(supabase, options.apikey, appId, OrganizationPerm.write, silent, true)
 
   if (!silent) {

--- a/src/bundle/list.ts
+++ b/src/bundle/list.ts
@@ -3,7 +3,7 @@ import { intro, log, outro } from '@clack/prompts'
 import { check2FAComplianceForApp, checkAppExistsAndHasPermissionOrgErr } from '../api/app'
 import { checkAlerts } from '../api/update'
 import { displayBundles, getActiveAppVersions } from '../api/versions'
-import { createSupabaseClient, findSavedKey, getAppId, getConfig, OrganizationPerm, verifyUser } from '../utils'
+import { createSupabaseClient, findSavedKey, getAppId, getConfig, OrganizationPerm, resolveUserIdFromApiKey } from '../utils'
 
 export async function listBundle(appId: string, options: OptionsBase, silent = false) {
   if (!silent)
@@ -28,7 +28,7 @@ export async function listBundle(appId: string, options: OptionsBase, silent = f
 
   const supabase = await createSupabaseClient(options.apikey, options.supaHost, options.supaAnon)
   await check2FAComplianceForApp(supabase, appId, silent)
-  await verifyUser(supabase, options.apikey, ['write', 'all', 'read', 'upload'])
+  await resolveUserIdFromApiKey(supabase, options.apikey)
   await checkAppExistsAndHasPermissionOrgErr(supabase, options.apikey, appId, OrganizationPerm.read, silent, true)
 
   if (!silent)

--- a/src/bundle/unlink.ts
+++ b/src/bundle/unlink.ts
@@ -13,8 +13,8 @@ import {
   getConfig,
   getOrganizationId,
   OrganizationPerm,
+  resolveUserIdFromApiKey,
   sendEvent,
-  verifyUser,
 } from '../utils'
 
 export async function unlinkDeviceInternal(
@@ -69,7 +69,7 @@ export async function unlinkDeviceInternal(
     await check2FAComplianceForApp(supabase, resolvedAppId, silent)
 
     const [userId, orgId] = await Promise.all([
-      verifyUser(supabase, enrichedOptions.apikey, ['all', 'write']),
+      resolveUserIdFromApiKey(supabase, enrichedOptions.apikey),
       getOrganizationId(supabase, resolvedAppId),
     ])
 

--- a/src/bundle/upload.ts
+++ b/src/bundle/upload.ts
@@ -19,7 +19,7 @@ import { checkAlerts } from '../api/update'
 import { getChecksum } from '../checksum'
 import { getRepoStarStatus, isRepoStarredInSession, starRepository } from '../github'
 import { showReplicationProgress } from '../replicationProgress'
-import { baseKeyV2, BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, checkChecksum, checkCompatibilityCloud, checkPlanValidUpload, checkRemoteCliMessages, createSupabaseClient, deletedFailedVersion, findRoot, findSavedKey, formatError, getAppId, getBundleVersion, getCompatibilityDetails, getConfig, getInstalledVersion, getLocalConfig, getLocalDependencies, getOrganizationId, getPMAndCommand, getRemoteFileConfig, hasCliPermission, hasOrganizationPerm, isCompatible, isDeprecatedPluginVersion, OrganizationPerm, regexSemver, resolveUserIdFromApiKey, sendEvent, updateConfigUpdater, updateOrCreateChannel, updateOrCreateVersion, UPLOAD_TIMEOUT, uploadTUS, uploadUrl, zipFile } from '../utils'
+import { baseKeyV2, BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, checkChecksum, checkCompatibilityCloud, checkPlanValidUpload, checkRemoteCliMessages, createSupabaseClient, deletedFailedVersion, findRoot, findSavedKey, formatError, getAppId, getBundleVersion, getCompatibilityDetails, getConfig, getInstalledVersion, getLocalConfig, getLocalDependencies, getOrganizationId, getPMAndCommand, getRemoteFileConfig, hasOrganizationPerm, isCompatible, isDeprecatedPluginVersion, OrganizationPerm, regexSemver, resolveUserIdFromApiKey, sendEvent, updateConfigUpdater, updateOrCreateChannel, updateOrCreateVersion, UPLOAD_TIMEOUT, uploadTUS, uploadUrl, zipFile } from '../utils'
 import { getVersionSuggestions, interactiveVersionBump } from '../versionHelpers'
 import { checkIndexPosition, searchInDirectory } from './check'
 import { prepareBundlePartialFiles, uploadPartial } from './partial'
@@ -645,26 +645,9 @@ async function setVersionInChannel(
   if (!versionId)
     uploadFail('Cannot get version id, cannot set channel')
 
-  const { data: existingChannel, error: channelLookupError } = await supabase
-    .from('channels')
-    .select('id')
-    .eq('app_id', appid)
-    .eq('name', channel)
-    .maybeSingle()
-
-  if (channelLookupError)
-    uploadFail(`Cannot look up channel ${channel} ${formatError(channelLookupError)}`)
-
-  const apiAccess = existingChannel?.id
-    ? await hasCliPermission(supabase, apikey, 'channel.update_settings', {
-        orgId,
-        appId: appid,
-        channelId: existingChannel.id,
-      })
-    : await hasCliPermission(supabase, apikey, 'app.create_channel', {
-        orgId,
-        appId: appid,
-      })
+  const { data: apiAccess } = await supabase
+    .rpc('is_allowed_capgkey', { apikey, keymode: ['write', 'all'] })
+    .single()
 
   if (apiAccess) {
     const { error: dbError3, data } = await updateOrCreateChannel(supabase, {

--- a/src/bundle/upload.ts
+++ b/src/bundle/upload.ts
@@ -19,7 +19,7 @@ import { checkAlerts } from '../api/update'
 import { getChecksum } from '../checksum'
 import { getRepoStarStatus, isRepoStarredInSession, starRepository } from '../github'
 import { showReplicationProgress } from '../replicationProgress'
-import { baseKeyV2, BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, checkChecksum, checkCompatibilityCloud, checkPlanValidUpload, checkRemoteCliMessages, createSupabaseClient, deletedFailedVersion, findRoot, findSavedKey, formatError, getAppId, getBundleVersion, getCompatibilityDetails, getConfig, getInstalledVersion, getLocalConfig, getLocalDependencies, getOrganizationId, getPMAndCommand, getRemoteFileConfig, hasOrganizationPerm, isCompatible, isDeprecatedPluginVersion, OrganizationPerm, regexSemver, sendEvent, updateConfigUpdater, updateOrCreateChannel, updateOrCreateVersion, UPLOAD_TIMEOUT, uploadTUS, uploadUrl, verifyUser, zipFile } from '../utils'
+import { baseKeyV2, BROTLI_MIN_UPDATER_VERSION_V5, BROTLI_MIN_UPDATER_VERSION_V6, BROTLI_MIN_UPDATER_VERSION_V7, checkChecksum, checkCompatibilityCloud, checkPlanValidUpload, checkRemoteCliMessages, createSupabaseClient, deletedFailedVersion, findRoot, findSavedKey, formatError, getAppId, getBundleVersion, getCompatibilityDetails, getConfig, getInstalledVersion, getLocalConfig, getLocalDependencies, getOrganizationId, getPMAndCommand, getRemoteFileConfig, hasCliPermission, hasOrganizationPerm, isCompatible, isDeprecatedPluginVersion, OrganizationPerm, regexSemver, resolveUserIdFromApiKey, sendEvent, updateConfigUpdater, updateOrCreateChannel, updateOrCreateVersion, UPLOAD_TIMEOUT, uploadTUS, uploadUrl, zipFile } from '../utils'
 import { getVersionSuggestions, interactiveVersionBump } from '../versionHelpers'
 import { checkIndexPosition, searchInDirectory } from './check'
 import { prepareBundlePartialFiles, uploadPartial } from './partial'
@@ -645,9 +645,26 @@ async function setVersionInChannel(
   if (!versionId)
     uploadFail('Cannot get version id, cannot set channel')
 
-  const { data: apiAccess } = await supabase
-    .rpc('is_allowed_capgkey', { apikey, keymode: ['write', 'all'] })
-    .single()
+  const { data: existingChannel, error: channelLookupError } = await supabase
+    .from('channels')
+    .select('id')
+    .eq('app_id', appid)
+    .eq('name', channel)
+    .maybeSingle()
+
+  if (channelLookupError)
+    uploadFail(`Cannot look up channel ${channel} ${formatError(channelLookupError)}`)
+
+  const apiAccess = existingChannel?.id
+    ? await hasCliPermission(supabase, apikey, 'channel.update_settings', {
+        orgId,
+        appId: appid,
+        channelId: existingChannel.id,
+      })
+    : await hasCliPermission(supabase, apikey, 'app.create_channel', {
+        orgId,
+        appId: appid,
+      })
 
   if (apiAccess) {
     const { error: dbError3, data } = await updateOrCreateChannel(supabase, {
@@ -798,7 +815,7 @@ export async function uploadBundleInternal(preAppid: string, options: OptionsUpl
   // Check 2FA compliance early to give a clear error message
   await check2FAComplianceForApp(supabase, appid, silent)
 
-  const userId = await verifyUser(supabase, apikey, ['write', 'all', 'upload'])
+  const userId = await resolveUserIdFromApiKey(supabase, apikey)
   if (options.verbose)
     log.info(`[Verbose] User verified successfully, user_id: ${userId}`)
 

--- a/src/channel/add.ts
+++ b/src/channel/add.ts
@@ -10,8 +10,8 @@ import {
   getConfig,
   getOrganizationId,
   OrganizationPerm,
+  resolveUserIdFromApiKey,
   sendEvent,
-  verifyUser,
 } from '../utils'
 
 export async function addChannelInternal(channelId: string, appId: string, options: ChannelAddOptions, silent = false) {
@@ -36,7 +36,7 @@ export async function addChannelInternal(channelId: string, appId: string, optio
 
   const supabase = await createSupabaseClient(options.apikey, options.supaHost, options.supaAnon)
   await check2FAComplianceForApp(supabase, appId, silent)
-  await verifyUser(supabase, options.apikey, ['write', 'all'])
+  await resolveUserIdFromApiKey(supabase, options.apikey)
   await checkAppExistsAndHasPermissionOrgErr(supabase, options.apikey, appId, OrganizationPerm.admin, silent, true)
 
   if (!silent)
@@ -50,7 +50,7 @@ export async function addChannelInternal(channelId: string, appId: string, optio
   }
 
   const orgId = await getOrganizationId(supabase, appId)
-  const userId = await verifyUser(supabase, options.apikey, ['write', 'all'])
+  const userId = await resolveUserIdFromApiKey(supabase, options.apikey)
 
   const res = await createChannel(supabase, {
     name: channelId,

--- a/src/channel/currentBundle.ts
+++ b/src/channel/currentBundle.ts
@@ -7,7 +7,7 @@ import {
   getAppId,
   getConfig,
   OrganizationPerm,
-  verifyUser,
+  resolveUserIdFromApiKey,
 } from '../utils'
 
 interface Channel {
@@ -40,7 +40,7 @@ export async function currentBundleInternal(channel: string, appId: string, opti
 
   const supabase = await createSupabaseClient(options.apikey, options.supaHost, options.supaAnon)
   await check2FAComplianceForApp(supabase, appId, silent)
-  await verifyUser(supabase, options.apikey, ['write', 'all', 'read'])
+  await resolveUserIdFromApiKey(supabase, options.apikey)
   await checkAppExistsAndHasPermissionOrgErr(supabase, options.apikey, appId, OrganizationPerm.read, silent, true)
 
   if (!channel) {

--- a/src/channel/delete.ts
+++ b/src/channel/delete.ts
@@ -11,8 +11,8 @@ import {
   getConfig,
   getOrganizationId,
   OrganizationPerm,
+  resolveUserIdFromApiKey,
   sendEvent,
-  verifyUser,
 } from '../utils'
 
 export async function deleteChannelInternal(channelId: string, appId: string, options: ChannelDeleteOptions, silent = false) {
@@ -37,7 +37,7 @@ export async function deleteChannelInternal(channelId: string, appId: string, op
 
   const supabase = await createSupabaseClient(options.apikey, options.supaHost, options.supaAnon)
   await check2FAComplianceForApp(supabase, appId, silent)
-  const userId = await verifyUser(supabase, options.apikey, ['all'])
+  const userId = await resolveUserIdFromApiKey(supabase, options.apikey)
 
   await checkAppExistsAndHasPermissionOrgErr(supabase, options.apikey, appId, OrganizationPerm.admin, silent, true)
 

--- a/src/channel/list.ts
+++ b/src/channel/list.ts
@@ -2,7 +2,7 @@ import type { OptionsBase } from '../schemas/base'
 import { intro, log, outro } from '@clack/prompts'
 import { check2FAComplianceForApp, checkAppExistsAndHasPermissionOrgErr } from '../api/app'
 import { displayChannels, getActiveChannels } from '../api/channels'
-import { createSupabaseClient, findSavedKey, getAppId, getConfig, OrganizationPerm, sendEvent, verifyUser } from '../utils'
+import { createSupabaseClient, findSavedKey, getAppId, getConfig, OrganizationPerm, resolveUserIdFromApiKey, sendEvent } from '../utils'
 
 export async function listChannelsInternal(appId: string, options: OptionsBase, silent = false) {
   if (!silent)
@@ -26,7 +26,7 @@ export async function listChannelsInternal(appId: string, options: OptionsBase, 
 
   const supabase = await createSupabaseClient(options.apikey, options.supaHost, options.supaAnon)
   await check2FAComplianceForApp(supabase, appId, silent)
-  const userId = await verifyUser(supabase, options.apikey, ['write', 'all', 'read', 'upload'])
+  const userId = await resolveUserIdFromApiKey(supabase, options.apikey)
 
   await checkAppExistsAndHasPermissionOrgErr(supabase, options.apikey, appId, OrganizationPerm.read, silent, true)
 

--- a/src/channel/set.ts
+++ b/src/channel/set.ts
@@ -16,9 +16,9 @@ import {
   getOrganizationId,
   isCompatible,
   OrganizationPerm,
+  resolveUserIdFromApiKey,
   sendEvent,
   updateOrCreateChannel,
-  verifyUser,
 } from '../utils'
 
 /**
@@ -78,7 +78,7 @@ export async function setChannelInternal(channel: string, appId: string, options
 
   const supabase = await createSupabaseClient(options.apikey, options.supaHost, options.supaAnon)
   await check2FAComplianceForApp(supabase, appId, silent)
-  const userId = await verifyUser(supabase, options.apikey, ['write', 'all'])
+  const userId = await resolveUserIdFromApiKey(supabase, options.apikey)
 
   await checkAppExistsAndHasPermissionOrgErr(supabase, options.apikey, appId, OrganizationPerm.admin, silent, true)
   const orgId = await getOrganizationId(supabase, appId)

--- a/src/init/command.ts
+++ b/src/init/command.ts
@@ -20,7 +20,7 @@ import { getRepoStarStatus, isRepoStarredInSession, starAllRepositories, starRep
 import { createKeyInternal } from '../key'
 import { doLoginExists, loginInternal } from '../login'
 import { showReplicationProgress } from '../replicationProgress'
-import { createSupabaseClient, findBuildCommandForProjectType, findMainFile, findMainFileForProjectType, findProjectType, findRoot, findSavedKey, formatError, getAllPackagesDependencies, getAppId, getBundleVersion, getConfig, getInstalledVersion, getLocalConfig, getNativeProjectResetAdvice, getPackageScripts, getPMAndCommand, PACKNAME, projectIsMonorepo, updateConfigbyKey, updateConfigUpdater, validateIosUpdaterSync, verifyUser } from '../utils'
+import { createSupabaseClient, findBuildCommandForProjectType, findMainFile, findMainFileForProjectType, findProjectType, findRoot, findSavedKey, formatError, getAllPackagesDependencies, getAppId, getBundleVersion, getConfig, getInstalledVersion, getLocalConfig, getNativeProjectResetAdvice, getPackageScripts, getPMAndCommand, hasCliPermission, PACKNAME, projectIsMonorepo, resolveUserIdFromApiKey, updateConfigbyKey, updateConfigUpdater, validateIosUpdaterSync } from '../utils'
 import { cancel as pCancel, confirm as pConfirm, intro as pIntro, isCancel as pIsCancel, log as pLog, outro as pOutro, select as pSelect, spinner as pSpinner, text as pText } from './prompts'
 import { setInitVersionWarning, stopInitInkSession } from './runtime'
 import { formatInitResumeMessage, initOnboardingSteps, renderInitOnboardingComplete, renderInitOnboardingFrame, renderInitOnboardingWelcome } from './ui'
@@ -924,7 +924,7 @@ async function maybeReusePendingOnboardingApp(
 
 async function selectOrganizationForInit(
   supabase: Awaited<ReturnType<typeof createSupabaseClient>>,
-  roles: string[],
+  apikey: string,
 ): Promise<Organization> {
   const { error: orgError, data: allOrganizations } = await supabase.rpc('get_orgs_v7')
 
@@ -934,24 +934,28 @@ async function selectOrganizationForInit(
     throw new Error('Cannot get the list of organizations')
   }
 
-  const normalizeRole = (role: string | null | undefined) => role?.replace(/^org_/, '') ?? ''
-  const normalizedRoles = new Set(roles.map(role => normalizeRole(role)))
-  const adminOrgs = allOrganizations.filter(org => normalizedRoles.has(normalizeRole(org.role)))
-
   if (allOrganizations.length === 0) {
     pLog.error('Could not get organization please create an organization first')
     throw new Error('No organizations available')
   }
 
-  if (adminOrgs.length === 0) {
-    pLog.error(`Could not find organization with roles: ${roles.join(' or ')} please create an organization or ask the admin to add you to the organization with this roles`)
+  const permissionChecks = await Promise.all(
+    allOrganizations.map(async (org) => {
+      const allowed = await hasCliPermission(supabase, apikey, 'org.create_app', { orgId: org.gid })
+      return allowed ? org : null
+    }),
+  )
+  const allowedOrganizations = permissionChecks.filter((org): org is Organization => org !== null)
+
+  if (allowedOrganizations.length === 0) {
+    pLog.error('Could not find organization with permission org.create_app. Ask an organization admin to grant app creation access.')
     throw new Error('Could not find organization with required roles')
   }
 
-  const organizationUidRaw = adminOrgs.length > 1
+  const organizationUidRaw = allowedOrganizations.length > 1
     ? await pSelect({
         message: 'Pick the organization that should own this app',
-        options: adminOrgs.map((org) => {
+        options: allowedOrganizations.map((org) => {
           const twoFaWarning = (org.enforcing_2fa && !org['2fa_has_access']) ? '2FA required' : undefined
           return {
             value: org.gid,
@@ -960,7 +964,7 @@ async function selectOrganizationForInit(
           }
         }),
       })
-    : adminOrgs[0].gid
+    : allowedOrganizations[0].gid
 
   if (pIsCancel(organizationUidRaw)) {
     pOutro('Bye 👋\n💡 You can resume the onboarding anytime by running the same command again')
@@ -2385,7 +2389,7 @@ export async function initApp(apikeyCommand: string, appId: string, options: Sup
   }
 
   const supabase = await createSupabaseClient(options.apikey, options.supaHost, options.supaAnon)
-  await verifyUser(supabase, options.apikey, ['upload', 'all', 'read', 'write'])
+  await resolveUserIdFromApiKey(supabase, options.apikey)
 
   // Try to resume from saved state before asking for org selection
   const resumed = await tryResumeOnboarding(options.apikey)
@@ -2398,29 +2402,30 @@ export async function initApp(apikeyCommand: string, appId: string, options: Sup
     if (orgError || !allOrganizations) {
       pLog.error(`Cannot verify organization access: ${orgError ? JSON.stringify(orgError) : 'no data returned'}`)
       pLog.warn('Falling back to organization selection.')
-      organization = await selectOrganizationForInit(supabase, ['admin', 'super_admin'])
+      organization = await selectOrganizationForInit(supabase, options.apikey)
       stepToSkip = 0
     }
     else {
       const savedOrg = allOrganizations.find(org => org.gid === resumed.orgId)
-      const normalizeRole = (role: string | null | undefined) => role?.replace(/^org_/, '') ?? ''
-      const hasRequiredRole = savedOrg && ['admin', 'super_admin'].includes(normalizeRole(savedOrg.role))
       const blocked2fa = savedOrg?.enforcing_2fa && !savedOrg['2fa_has_access']
+      const hasCreateAppPermission = savedOrg
+        ? await hasCliPermission(supabase, options.apikey, 'org.create_app', { orgId: savedOrg.gid })
+        : false
 
       if (!savedOrg) {
         pLog.warn(`Previously used organization "${resumed.orgName}" is no longer available. Please select a new one.`)
-        organization = await selectOrganizationForInit(supabase, ['admin', 'super_admin'])
+        organization = await selectOrganizationForInit(supabase, options.apikey)
         stepToSkip = 0
       }
-      else if (!hasRequiredRole) {
-        pLog.warn(`You no longer have admin access to "${savedOrg.name}". Please select a different organization.`)
-        organization = await selectOrganizationForInit(supabase, ['admin', 'super_admin'])
+      else if (!hasCreateAppPermission) {
+        pLog.warn(`You no longer have permission to create an app in "${savedOrg.name}". Please select a different organization.`)
+        organization = await selectOrganizationForInit(supabase, options.apikey)
         stepToSkip = 0
       }
       else if (blocked2fa) {
         pLog.warn(`Organization "${savedOrg.name}" now requires 2FA. Enable it at https://web.capgo.app/settings/account`)
         pLog.warn('Please select a different organization or enable 2FA and try again.')
-        organization = await selectOrganizationForInit(supabase, ['admin', 'super_admin'])
+        organization = await selectOrganizationForInit(supabase, options.apikey)
         stepToSkip = 0
       }
       else {
@@ -2430,7 +2435,7 @@ export async function initApp(apikeyCommand: string, appId: string, options: Sup
     }
   }
   else {
-    organization = await selectOrganizationForInit(supabase, ['admin', 'super_admin'])
+    organization = await selectOrganizationForInit(supabase, options.apikey)
   }
 
   const orgId = organization.gid

--- a/src/init/command.ts
+++ b/src/init/command.ts
@@ -20,7 +20,7 @@ import { getRepoStarStatus, isRepoStarredInSession, starAllRepositories, starRep
 import { createKeyInternal } from '../key'
 import { doLoginExists, loginInternal } from '../login'
 import { showReplicationProgress } from '../replicationProgress'
-import { createSupabaseClient, findBuildCommandForProjectType, findMainFile, findMainFileForProjectType, findProjectType, findRoot, findSavedKey, formatError, getAllPackagesDependencies, getAppId, getBundleVersion, getConfig, getInstalledVersion, getLocalConfig, getNativeProjectResetAdvice, getPackageScripts, getPMAndCommand, hasCliPermission, PACKNAME, projectIsMonorepo, resolveUserIdFromApiKey, updateConfigbyKey, updateConfigUpdater, validateIosUpdaterSync } from '../utils'
+import { createSupabaseClient, filterOrgsByPermission, findBuildCommandForProjectType, findMainFile, findMainFileForProjectType, findProjectType, findRoot, findSavedKey, formatError, getAllPackagesDependencies, getAppId, getBundleVersion, getConfig, getInstalledVersion, getLocalConfig, getNativeProjectResetAdvice, getPackageScripts, getPMAndCommand, hasCliPermission, PACKNAME, projectIsMonorepo, resolveUserIdFromApiKey, updateConfigbyKey, updateConfigUpdater, validateIosUpdaterSync } from '../utils'
 import { cancel as pCancel, confirm as pConfirm, intro as pIntro, isCancel as pIsCancel, log as pLog, outro as pOutro, select as pSelect, spinner as pSpinner, text as pText } from './prompts'
 import { setInitVersionWarning, stopInitInkSession } from './runtime'
 import { formatInitResumeMessage, initOnboardingSteps, renderInitOnboardingComplete, renderInitOnboardingFrame, renderInitOnboardingWelcome } from './ui'
@@ -939,13 +939,7 @@ async function selectOrganizationForInit(
     throw new Error('No organizations available')
   }
 
-  const permissionChecks = await Promise.all(
-    allOrganizations.map(async (org) => {
-      const allowed = await hasCliPermission(supabase, apikey, 'org.create_app', { orgId: org.gid })
-      return allowed ? org : null
-    }),
-  )
-  const allowedOrganizations = permissionChecks.filter((org): org is Organization => org !== null)
+  const allowedOrganizations = await filterOrgsByPermission(supabase, apikey, allOrganizations, 'org.create_app')
 
   if (allowedOrganizations.length === 0) {
     pLog.error('Could not find organization with permission org.create_app. Ask an organization admin to grant app creation access.')

--- a/src/init/command.ts
+++ b/src/init/command.ts
@@ -20,7 +20,7 @@ import { getRepoStarStatus, isRepoStarredInSession, starAllRepositories, starRep
 import { createKeyInternal } from '../key'
 import { doLoginExists, loginInternal } from '../login'
 import { showReplicationProgress } from '../replicationProgress'
-import { createSupabaseClient, filterOrgsByPermission, findBuildCommandForProjectType, findMainFile, findMainFileForProjectType, findProjectType, findRoot, findSavedKey, formatError, getAllPackagesDependencies, getAppId, getBundleVersion, getConfig, getInstalledVersion, getLocalConfig, getNativeProjectResetAdvice, getPackageScripts, getPMAndCommand, hasCliPermission, PACKNAME, projectIsMonorepo, resolveUserIdFromApiKey, updateConfigbyKey, updateConfigUpdater, validateIosUpdaterSync } from '../utils'
+import { createSupabaseClient, findBuildCommandForProjectType, findMainFile, findMainFileForProjectType, findProjectType, findRoot, findSavedKey, formatError, getAllPackagesDependencies, getAppId, getBundleVersion, getConfig, getInstalledVersion, getLocalConfig, getNativeProjectResetAdvice, getOrganizationListWithPermission, getPackageScripts, getPMAndCommand, hasCliPermission, PACKNAME, projectIsMonorepo, resolveUserIdFromApiKey, updateConfigbyKey, updateConfigUpdater, validateIosUpdaterSync } from '../utils'
 import { cancel as pCancel, confirm as pConfirm, intro as pIntro, isCancel as pIsCancel, log as pLog, outro as pOutro, select as pSelect, spinner as pSpinner, text as pText } from './prompts'
 import { setInitVersionWarning, stopInitInkSession } from './runtime'
 import { formatInitResumeMessage, initOnboardingSteps, renderInitOnboardingComplete, renderInitOnboardingFrame, renderInitOnboardingWelcome } from './ui'
@@ -926,25 +926,7 @@ async function selectOrganizationForInit(
   supabase: Awaited<ReturnType<typeof createSupabaseClient>>,
   apikey: string,
 ): Promise<Organization> {
-  const { error: orgError, data: allOrganizations } = await supabase.rpc('get_orgs_v7')
-
-  if (orgError) {
-    pLog.error('Cannot get the list of organizations - exiting')
-    pLog.error(`Error ${JSON.stringify(orgError)}`)
-    throw new Error('Cannot get the list of organizations')
-  }
-
-  if (allOrganizations.length === 0) {
-    pLog.error('Could not get organization please create an organization first')
-    throw new Error('No organizations available')
-  }
-
-  const allowedOrganizations = await filterOrgsByPermission(supabase, apikey, allOrganizations, 'org.create_app')
-
-  if (allowedOrganizations.length === 0) {
-    pLog.error('Could not find organization with permission org.create_app. Ask an organization admin to grant app creation access.')
-    throw new Error('Could not find organization with required roles')
-  }
+  const { allOrganizations, allowedOrganizations } = await getOrganizationListWithPermission(supabase, apikey, 'org.create_app')
 
   const organizationUidRaw = allowedOrganizations.length > 1
     ? await pSelect({

--- a/src/login.ts
+++ b/src/login.ts
@@ -2,7 +2,7 @@ import { existsSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { intro, isCancel, log, outro, password } from '@clack/prompts'
 import { checkAlerts } from './api/update'
-import { createSupabaseClient, sendEvent, verifyUser } from './utils'
+import { createSupabaseClient, resolveUserIdFromApiKey, sendEvent } from './utils'
 import { appendToSafeFile, writeFileAtomic } from './utils/safeWrites'
 
 interface Options {
@@ -51,7 +51,7 @@ export async function loginInternal(apikey: string, options: Options, silent = f
   }
 
   const supabase = await createSupabaseClient(apikey, options.supaHost, options.supaAnon)
-  const userId = await verifyUser(supabase, apikey, ['write', 'all', 'upload'])
+  const userId = await resolveUserIdFromApiKey(supabase, apikey)
 
   if (local) {
     await writeFileAtomic('.capgo', `${apikey}\n`, { mode: 0o600 })

--- a/src/organization/add.ts
+++ b/src/organization/add.ts
@@ -5,8 +5,8 @@ import {
   createSupabaseClient,
   findSavedKey,
   formatError,
+  resolveUserIdFromApiKey,
   sendEvent,
-  verifyUser,
 } from '../utils'
 
 export async function addOrganizationInternal(options: OrganizationAddOptions, silent = false) {
@@ -31,7 +31,7 @@ export async function addOrganizationInternal(options: OrganizationAddOptions, s
     enrichedOptions.supaHost,
     enrichedOptions.supaAnon,
   )
-  const userId = await verifyUser(supabase, enrichedOptions.apikey, ['write', 'all'])
+  const userId = await resolveUserIdFromApiKey(supabase, enrichedOptions.apikey)
 
   let { name, email } = enrichedOptions
 

--- a/src/organization/delete.ts
+++ b/src/organization/delete.ts
@@ -1,13 +1,14 @@
 import type { OrganizationDeleteOptions } from '../schemas/organization'
-import { confirm as confirmC, intro, isCancel, log, outro, select } from '@clack/prompts'
+import { confirm as confirmC, intro, isCancel, log, outro } from '@clack/prompts'
 import { checkAlerts } from '../api/update'
 import {
+  assertCliPermission,
   check2FAAccessForOrg,
   createSupabaseClient,
   findSavedKey,
   formatError,
+  resolveUserIdFromApiKey,
   sendEvent,
-  verifyUser,
 } from '../utils'
 
 export async function deleteOrganizationInternal(
@@ -42,7 +43,11 @@ export async function deleteOrganizationInternal(
     enrichedOptions.supaHost,
     enrichedOptions.supaAnon,
   )
-  const userId = await verifyUser(supabase, enrichedOptions.apikey, ['write', 'all'])
+  await resolveUserIdFromApiKey(supabase, enrichedOptions.apikey)
+  await assertCliPermission(supabase, enrichedOptions.apikey, 'org.delete', { orgId }, {
+    message: `Insufficient permissions to delete organization ${orgId}`,
+    silent,
+  })
 
   await check2FAAccessForOrg(supabase, orgId, silent)
 
@@ -56,28 +61,6 @@ export async function deleteOrganizationInternal(
     if (!silent)
       log.error(`Cannot get organization details ${formatError(orgError)}`)
     throw new Error(`Cannot get organization details: ${formatError(orgError)}`)
-  }
-
-  if (orgData.created_by !== userId) {
-    if (silent)
-      throw new Error('Deleting an organization is restricted to the organization owner')
-
-    log.warn('Deleting an organization is restricted to the organization owner')
-    log.warn('You are not the owner of this organization')
-    log.warn('It\'s strongly recommended that you do not continue!')
-
-    const shouldContinue = await select({
-      message: 'Do you want to continue?',
-      options: [
-        { label: 'Yes', value: 'yes' },
-        { label: 'No', value: 'no' },
-      ],
-    })
-
-    if (isCancel(shouldContinue) || shouldContinue === 'no') {
-      log.error('Canceled deleting the organization')
-      throw new Error('Organization deletion cancelled')
-    }
   }
 
   if (!silent && !enrichedOptions.autoConfirm) {

--- a/src/organization/delete.ts
+++ b/src/organization/delete.ts
@@ -2,12 +2,11 @@ import type { OrganizationDeleteOptions } from '../schemas/organization'
 import { confirm as confirmC, intro, isCancel, log, outro } from '@clack/prompts'
 import { checkAlerts } from '../api/update'
 import {
-  assertCliPermission,
+  assertOrgPermission,
   check2FAAccessForOrg,
   createSupabaseClient,
   findSavedKey,
   formatError,
-  resolveUserIdFromApiKey,
   sendEvent,
 } from '../utils'
 
@@ -43,11 +42,7 @@ export async function deleteOrganizationInternal(
     enrichedOptions.supaHost,
     enrichedOptions.supaAnon,
   )
-  await resolveUserIdFromApiKey(supabase, enrichedOptions.apikey)
-  await assertCliPermission(supabase, enrichedOptions.apikey, 'org.delete', { orgId }, {
-    message: `Insufficient permissions to delete organization ${orgId}`,
-    silent,
-  })
+  await assertOrgPermission(supabase, enrichedOptions.apikey, 'org.delete', orgId, `Insufficient permissions to delete organization ${orgId}`, silent)
 
   await check2FAAccessForOrg(supabase, orgId, silent)
 

--- a/src/organization/list.ts
+++ b/src/organization/list.ts
@@ -7,7 +7,7 @@ import {
   createSupabaseClient,
   findSavedKey,
   formatError,
-  verifyUser,
+  resolveUserIdFromApiKey,
 } from '../utils'
 
 function displayOrganizations(data: Organization[], silent: boolean) {
@@ -73,7 +73,7 @@ export async function listOrganizationsInternal(options: OptionsBase, silent = f
     enrichedOptions.supaHost,
     enrichedOptions.supaAnon,
   )
-  await verifyUser(supabase, enrichedOptions.apikey, ['read', 'write', 'all'])
+  await resolveUserIdFromApiKey(supabase, enrichedOptions.apikey)
 
   if (!silent)
     log.info('Getting organizations from Capgo')

--- a/src/organization/members.ts
+++ b/src/organization/members.ts
@@ -3,12 +3,11 @@ import { intro, log, outro } from '@clack/prompts'
 import { Table } from '@sauber/table'
 import { checkAlerts } from '../api/update'
 import {
-  assertCliPermission,
+  assertOrgPermission,
   check2FAAccessForOrg,
   createSupabaseClient,
   findSavedKey,
   formatError,
-  resolveUserIdFromApiKey,
 } from '../utils'
 
 interface PasswordPolicyConfig {
@@ -99,11 +98,7 @@ export async function listMembersInternal(orgId: string, options: OptionsBase, s
     enrichedOptions.supaHost,
     enrichedOptions.supaAnon,
   )
-  await resolveUserIdFromApiKey(supabase, enrichedOptions.apikey)
-  await assertCliPermission(supabase, enrichedOptions.apikey, 'org.read_members', { orgId }, {
-    message: `Insufficient permissions to list members of organization ${orgId}`,
-    silent,
-  })
+  await assertOrgPermission(supabase, enrichedOptions.apikey, 'org.read_members', orgId, `Insufficient permissions to list members of organization ${orgId}`, silent)
   await check2FAAccessForOrg(supabase, orgId, silent)
 
   // Get organization name and security settings

--- a/src/organization/members.ts
+++ b/src/organization/members.ts
@@ -3,11 +3,12 @@ import { intro, log, outro } from '@clack/prompts'
 import { Table } from '@sauber/table'
 import { checkAlerts } from '../api/update'
 import {
+  assertCliPermission,
   check2FAAccessForOrg,
   createSupabaseClient,
   findSavedKey,
   formatError,
-  verifyUser,
+  resolveUserIdFromApiKey,
 } from '../utils'
 
 interface PasswordPolicyConfig {
@@ -98,7 +99,11 @@ export async function listMembersInternal(orgId: string, options: OptionsBase, s
     enrichedOptions.supaHost,
     enrichedOptions.supaAnon,
   )
-  await verifyUser(supabase, enrichedOptions.apikey, ['read', 'write', 'all'])
+  await resolveUserIdFromApiKey(supabase, enrichedOptions.apikey)
+  await assertCliPermission(supabase, enrichedOptions.apikey, 'org.read_members', { orgId }, {
+    message: `Insufficient permissions to list members of organization ${orgId}`,
+    silent,
+  })
   await check2FAAccessForOrg(supabase, orgId, silent)
 
   // Get organization name and security settings

--- a/src/organization/set.ts
+++ b/src/organization/set.ts
@@ -2,12 +2,13 @@ import type { OrganizationSetOptions, PasswordPolicyConfig } from '../schemas/or
 import { confirm as confirmC, intro, isCancel, log, outro, text } from '@clack/prompts'
 import { checkAlerts } from '../api/update'
 import {
+  assertCliPermission,
   check2FAAccessForOrg,
   createSupabaseClient,
   findSavedKey,
   formatError,
+  resolveUserIdFromApiKey,
   sendEvent,
-  verifyUser,
 } from '../utils'
 
 export async function setOrganizationInternal(
@@ -42,7 +43,11 @@ export async function setOrganizationInternal(
     enrichedOptions.supaHost,
     enrichedOptions.supaAnon,
   )
-  await verifyUser(supabase, enrichedOptions.apikey, ['write', 'all'])
+  await resolveUserIdFromApiKey(supabase, enrichedOptions.apikey)
+  await assertCliPermission(supabase, enrichedOptions.apikey, 'org.update_settings', { orgId }, {
+    message: `Insufficient permissions to update organization ${orgId}`,
+    silent,
+  })
 
   await check2FAAccessForOrg(supabase, orgId, silent)
 

--- a/src/organization/set.ts
+++ b/src/organization/set.ts
@@ -2,12 +2,11 @@ import type { OrganizationSetOptions, PasswordPolicyConfig } from '../schemas/or
 import { confirm as confirmC, intro, isCancel, log, outro, text } from '@clack/prompts'
 import { checkAlerts } from '../api/update'
 import {
-  assertCliPermission,
+  assertOrgPermission,
   check2FAAccessForOrg,
   createSupabaseClient,
   findSavedKey,
   formatError,
-  resolveUserIdFromApiKey,
   sendEvent,
 } from '../utils'
 
@@ -43,11 +42,7 @@ export async function setOrganizationInternal(
     enrichedOptions.supaHost,
     enrichedOptions.supaAnon,
   )
-  await resolveUserIdFromApiKey(supabase, enrichedOptions.apikey)
-  await assertCliPermission(supabase, enrichedOptions.apikey, 'org.update_settings', { orgId }, {
-    message: `Insufficient permissions to update organization ${orgId}`,
-    silent,
-  })
+  await assertOrgPermission(supabase, enrichedOptions.apikey, 'org.update_settings', orgId, `Insufficient permissions to update organization ${orgId}`, silent)
 
   await check2FAAccessForOrg(supabase, orgId, silent)
 

--- a/src/user/account.ts
+++ b/src/user/account.ts
@@ -1,6 +1,6 @@
 import type { Options } from '../api/app'
 import { intro, log, outro } from '@clack/prompts'
-import { createSupabaseClient, findSavedKey, formatError, verifyUser } from '../utils'
+import { createSupabaseClient, findSavedKey, formatError, resolveUserIdFromApiKey } from '../utils'
 
 export async function getUserIdInternal(options: Options, silent = false) {
   if (!silent)
@@ -23,7 +23,7 @@ export async function getUserIdInternal(options: Options, silent = false) {
       enrichedOptions.supaHost,
       enrichedOptions.supaAnon,
     )
-    const userId = await verifyUser(supabase, enrichedOptions.apikey, ['read', 'all', 'write'])
+    const userId = await resolveUserIdFromApiKey(supabase, enrichedOptions.apikey)
 
     if (!silent)
       outro(`Done ✅: ${userId}`)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -620,28 +620,6 @@ export async function createSupabaseClient(apikey: string, supaHost?: string, su
   })
 }
 
-export async function checkKey(supabase: SupabaseClient<Database>, apikey: string, keymode: Database['public']['Enums']['key_mode'][]) {
-  const { data: apiAccess } = await supabase
-    .rpc('is_allowed_capgkey', { apikey, keymode })
-    .single()
-
-  if (!apiAccess) {
-    log.error(`Invalid API key or insufficient permissions.`)
-    // create a string from keymode array with comma and space and "or" for the last one
-    const keymodeStr = keymode.map((k, i) => {
-      if (keymode.length === 1)
-        return `"${k}"`
-      if (i === keymode.length - 1)
-        return `or "${k}"`
-
-      return `"${k}", `
-    }).join('')
-    const message = `Your key should be: ${keymodeStr} mode.`
-    log.error(message)
-    throw new Error('Invalid API key or insufficient permissions.')
-  }
-}
-
 export async function isPayingOrg(supabase: SupabaseClient<Database>, orgId: string): Promise<boolean> {
   const { data } = await supabase
     .rpc('is_paying_org', { orgid: orgId })
@@ -691,7 +669,7 @@ export const hasOrganizationPerm = (perm: OrganizationPerm, required: Organizati
 
 export async function isAllowedAppOrg(supabase: SupabaseClient<Database>, apikey: string, appId: string): Promise<{ okay: true, data: OrganizationPerm } | { okay: false, error: 'INVALID_APIKEY' | 'NO_APP' | 'NO_ORG' }> {
   const { data, error } = await supabase
-    .rpc('get_org_perm_for_apikey', { apikey, app_id: appId })
+    .rpc('get_org_perm_for_apikey_v2' as any, { apikey, app_id: appId })
     .single()
 
   if (error) {
@@ -971,27 +949,33 @@ export async function findProjectType(options?: { quiet?: boolean }) {
   for await (const f of getFiles(pwd)) {
     // find number of folder in path after pwd
     if (f.includes('angular.json')) {
-      if (!quiet) log.info('Found angular project')
+      if (!quiet)
+        log.info('Found angular project')
       return isTypeScript ? 'angular-ts' : 'angular-js'
     }
     if (f.includes('nuxt.config.js') || f.includes('nuxt.config.ts')) {
-      if (!quiet) log.info('Found nuxtjs project')
+      if (!quiet)
+        log.info('Found nuxtjs project')
       return isTypeScript ? 'nuxtjs-ts' : 'nuxtjs-js'
     }
     if (f.includes('next.config.js') || f.includes('next.config.mjs')) {
-      if (!quiet) log.info('Found nextjs project')
+      if (!quiet)
+        log.info('Found nextjs project')
       return isTypeScript ? 'nextjs-ts' : 'nextjs-js'
     }
     if (f.includes('svelte.config.js')) {
-      if (!quiet) log.info('Found sveltekit project')
+      if (!quiet)
+        log.info('Found sveltekit project')
       return isTypeScript ? 'sveltekit-ts' : 'sveltekit-js'
     }
     if (f.includes('rolluconfig.js')) {
-      if (!quiet) log.info('Found svelte project')
+      if (!quiet)
+        log.info('Found svelte project')
       return isTypeScript ? 'svelte-ts' : 'svelte-js'
     }
     if (f.includes('vue.config.js')) {
-      if (!quiet) log.info('Found vue project')
+      if (!quiet)
+        log.info('Found vue project')
       return isTypeScript ? 'vue-ts' : 'vue-js'
     }
     if (f.includes(PACKNAME)) {
@@ -999,11 +983,13 @@ export async function findProjectType(options?: { quiet?: boolean }) {
       const dependencies = await getAllPackagesDependencies(folder)
       if (dependencies) {
         if (dependencies.get('react')) {
-          if (!quiet) log.info('Found react project')
+          if (!quiet)
+            log.info('Found react project')
           return isTypeScript ? 'react-ts' : 'react-js'
         }
         if (dependencies.get('vue')) {
-          if (!quiet) log.info('Found vue project')
+          if (!quiet)
+            log.info('Found vue project')
           return isTypeScript ? 'vue-ts' : 'vue-js'
         }
       }
@@ -1480,9 +1466,65 @@ export async function getOrganization(supabase: SupabaseClient<Database>, roles:
   return organization
 }
 
-export async function verifyUser(supabase: SupabaseClient<Database>, apikey: string, keymod: Database['public']['Enums']['key_mode'][] = ['all']) {
-  await checkKey(supabase, apikey, keymod)
+export async function getOrganizationWithPermission(
+  supabase: SupabaseClient<Database>,
+  apikey: string,
+  permissionKey: string,
+): Promise<Organization> {
+  const { error: orgError, data: allOrganizations } = await supabase
+    .rpc('get_orgs_v7')
 
+  if (orgError) {
+    log.error('Cannot get the list of organizations - exiting')
+    log.error(`Error ${JSON.stringify(orgError)}`)
+    throw new Error('Cannot get the list of organizations')
+  }
+
+  if (allOrganizations.length === 0) {
+    log.error('Could not get organization please create an organization first')
+    throw new Error('No organizations available')
+  }
+
+  const permissionChecks = await Promise.all(
+    allOrganizations.map(async (org) => {
+      const allowed = await hasCliPermission(supabase, apikey, permissionKey, { orgId: org.gid })
+      return allowed ? org : null
+    }),
+  )
+  const allowedOrganizations = permissionChecks.filter((org): org is Organization => org !== null)
+
+  if (allowedOrganizations.length === 0) {
+    log.error(`Could not find organization with permission: ${permissionKey}`)
+    throw new Error('Could not find organization with required permission')
+  }
+
+  const organizationUidRaw = (allowedOrganizations.length > 1)
+    ? await select({
+        message: 'Please pick the organization that you want to insert to',
+        options: allowedOrganizations.map((org) => {
+          const twoFaWarning = (org.enforcing_2fa && !org['2fa_has_access']) ? ' ⚠️ (2FA required)' : ''
+          return { value: org.gid, label: `${org.name}${twoFaWarning}` }
+        }),
+      })
+    : allowedOrganizations[0].gid
+
+  if (isCancel(organizationUidRaw)) {
+    log.error('Canceled organization selection, exiting')
+    throw new Error('Organization selection cancelled')
+  }
+
+  const organizationUid = organizationUidRaw as string
+  const organization = allOrganizations.find(org => org.gid === organizationUid)!
+
+  if (organization.enforcing_2fa && !organization['2fa_has_access']) {
+    show2FADeniedError(organization.name)
+  }
+
+  log.info(`Using the organization "${organization.name}" as the app owner`)
+  return organization
+}
+
+export async function resolveUserIdFromApiKey(supabase: SupabaseClient<Database>, apikey: string) {
   const { data: dataUser, error: userIdError } = await supabase
     .rpc('get_user_id', { apikey })
     .single()
@@ -1494,6 +1536,70 @@ export async function verifyUser(supabase: SupabaseClient<Database>, apikey: str
     throw new Error('Cannot authenticate user with provided API key')
   }
   return userId
+}
+
+interface CliPermissionScope {
+  orgId?: string | null
+  appId?: string | null
+  channelId?: number | null
+}
+
+export async function hasCliPermission(
+  supabase: SupabaseClient<Database>,
+  apikey: string,
+  permissionKey: string,
+  scope: CliPermissionScope = {},
+): Promise<boolean> {
+  const { data, error } = await supabase.rpc('cli_check_permission' as any, {
+    apikey,
+    permission_key: permissionKey,
+    org_id: scope.orgId ?? null,
+    app_id: scope.appId ?? null,
+    channel_id: scope.channelId ?? null,
+  })
+
+  if (error) {
+    log.error(`Cannot check permission ${permissionKey}`)
+    log.error(formatError(error))
+    throw new Error(`Cannot check permission ${permissionKey}`)
+  }
+
+  return !!data
+}
+
+export async function assertCliPermission(
+  supabase: SupabaseClient<Database>,
+  apikey: string,
+  permissionKey: string,
+  scope: CliPermissionScope = {},
+  options: {
+    message?: string
+    silent?: boolean
+  } = {},
+): Promise<void> {
+  const allowed = await hasCliPermission(supabase, apikey, permissionKey, scope)
+  if (allowed)
+    return
+
+  const message = options.message || `Insufficient permissions for ${permissionKey}`
+  if (!options.silent)
+    log.error(message)
+  throw new Error(message)
+}
+
+export async function getAccessibleAppsForApiKey(
+  supabase: SupabaseClient<Database>,
+  apikey: string,
+): Promise<Database['public']['Tables']['apps']['Row'][]> {
+  const { data, error } = await supabase.rpc('get_accessible_apps_for_apikey_v2' as any, { apikey })
+
+  if (error) {
+    log.error('Cannot get accessible apps for API key')
+    log.error(formatError(error))
+    throw new Error('Cannot get accessible apps for API key')
+  }
+
+  return (data || []) as Database['public']['Tables']['apps']['Row'][]
 }
 
 export async function getOrganizationId(supabase: SupabaseClient<Database>, appId: string) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -669,7 +669,7 @@ export const hasOrganizationPerm = (perm: OrganizationPerm, required: Organizati
 
 export async function isAllowedAppOrg(supabase: SupabaseClient<Database>, apikey: string, appId: string): Promise<{ okay: true, data: OrganizationPerm } | { okay: false, error: 'INVALID_APIKEY' | 'NO_APP' | 'NO_ORG' }> {
   const { data, error } = await supabase
-    .rpc('get_org_perm_for_apikey_v2' as any, { apikey, app_id: appId })
+    .rpc('get_org_perm_for_apikey', { apikey, app_id: appId })
     .single()
 
   if (error) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1524,7 +1524,7 @@ export async function getOrganizationWithPermission(
   return organization
 }
 
-export async function resolveUserIdFromApiKey(supabase: SupabaseClient<Database>, apikey: string) {
+export async function resolveUserIdFromApiKey(supabase: SupabaseClient<Database>, apikey: string, silent = false) {
   const { data: dataUser, error: userIdError } = await supabase
     .rpc('get_user_id', { apikey })
     .single()
@@ -1532,7 +1532,8 @@ export async function resolveUserIdFromApiKey(supabase: SupabaseClient<Database>
   const userId = (dataUser || '').toString()
 
   if (!userId || userIdError) {
-    log.error(`Invalid API key or insufficient permissions.`)
+    if (!silent)
+      log.error(`Invalid API key or insufficient permissions.`)
     throw new Error('Invalid API key or insufficient permissions.')
   }
   return userId

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1481,13 +1481,12 @@ export async function filterOrgsByPermission(
   return checks.filter((org): org is Organization => org !== null)
 }
 
-export async function getOrganizationWithPermission(
+export async function getOrganizationListWithPermission(
   supabase: SupabaseClient<Database>,
   apikey: string,
   permissionKey: string,
-): Promise<Organization> {
-  const { error: orgError, data: allOrganizations } = await supabase
-    .rpc('get_orgs_v7')
+): Promise<{ allOrganizations: Organization[], allowedOrganizations: Organization[] }> {
+  const { error: orgError, data: allOrganizations } = await supabase.rpc('get_orgs_v7')
 
   if (orgError) {
     log.error('Cannot get the list of organizations - exiting')
@@ -1506,6 +1505,16 @@ export async function getOrganizationWithPermission(
     log.error(`Could not find organization with permission: ${permissionKey}`)
     throw new Error('Could not find organization with required permission')
   }
+
+  return { allOrganizations, allowedOrganizations }
+}
+
+export async function getOrganizationWithPermission(
+  supabase: SupabaseClient<Database>,
+  apikey: string,
+  permissionKey: string,
+): Promise<Organization> {
+  const { allOrganizations, allowedOrganizations } = await getOrganizationListWithPermission(supabase, apikey, permissionKey)
 
   const organizationUidRaw = (allowedOrganizations.length > 1)
     ? await select({

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1507,7 +1507,7 @@ export async function getOrganizationListWithPermission(
 
   if (orgError) {
     log.error('Cannot get the list of organizations - exiting')
-    log.error(`Error ${JSON.stringify(orgError)}`)
+    log.error(formatError(orgError))
     throw new Error('Cannot get the list of organizations')
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1532,8 +1532,8 @@ export async function resolveUserIdFromApiKey(supabase: SupabaseClient<Database>
   const userId = (dataUser || '').toString()
 
   if (!userId || userIdError) {
-    log.error(`Cannot auth user with apikey`)
-    throw new Error('Cannot authenticate user with provided API key')
+    log.error(`Invalid API key or insufficient permissions.`)
+    throw new Error('Invalid API key or insufficient permissions.')
   }
   return userId
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1623,6 +1623,18 @@ export async function assertCliPermission(
   throw new Error(message)
 }
 
+export async function assertOrgPermission(
+  supabase: SupabaseClient<Database>,
+  apikey: string,
+  permissionKey: string,
+  orgId: string,
+  message: string,
+  silent: boolean,
+): Promise<void> {
+  await resolveUserIdFromApiKey(supabase, apikey, silent)
+  await assertCliPermission(supabase, apikey, permissionKey, { orgId }, { message, silent })
+}
+
 export async function getAccessibleAppsForApiKey(
   supabase: SupabaseClient<Database>,
   apikey: string,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1466,6 +1466,21 @@ export async function getOrganization(supabase: SupabaseClient<Database>, roles:
   return organization
 }
 
+export async function filterOrgsByPermission(
+  supabase: SupabaseClient<Database>,
+  apikey: string,
+  orgs: Organization[],
+  permissionKey: string,
+): Promise<Organization[]> {
+  const checks = await Promise.all(
+    orgs.map(async (org) => {
+      const allowed = await hasCliPermission(supabase, apikey, permissionKey, { orgId: org.gid })
+      return allowed ? org : null
+    }),
+  )
+  return checks.filter((org): org is Organization => org !== null)
+}
+
 export async function getOrganizationWithPermission(
   supabase: SupabaseClient<Database>,
   apikey: string,
@@ -1485,13 +1500,7 @@ export async function getOrganizationWithPermission(
     throw new Error('No organizations available')
   }
 
-  const permissionChecks = await Promise.all(
-    allOrganizations.map(async (org) => {
-      const allowed = await hasCliPermission(supabase, apikey, permissionKey, { orgId: org.gid })
-      return allowed ? org : null
-    }),
-  )
-  const allowedOrganizations = permissionChecks.filter((org): org is Organization => org !== null)
+  const allowedOrganizations = await filterOrgsByPermission(supabase, apikey, allOrganizations, permissionKey)
 
   if (allowedOrganizations.length === 0) {
     log.error(`Could not find organization with permission: ${permissionKey}`)


### PR DESCRIPTION
## Summary (AI generated)

- Migrates CLI permission checks to RBAC-aware backend wrappers with legacy fallback semantics.
- Makes `login`, `user account`, and `organization add` identity-only instead of gating them on legacy key modes.
- Uses `org.create_app` for app creation and init organization selection.
- Removes now-unused legacy helpers from the CLI auth path.

## Motivation (AI generated)

The CLI still contained legacy `mode`-based checks that could conflict with or bypass the RBAC behavior now implemented in the backend. This change makes the CLI defer permission decisions to backend RBAC-aware checks while preserving the current fallback behavior for legacy keys.

## Business Impact (AI generated)

This brings the CLI in line with the console and public API authorization model, reducing surprising permission mismatches for customers using API Keys v2 and improving confidence in RBAC-based automation flows.

## Test Plan (AI generated)

- [ ] Run `bunx eslint "src/**/*.ts"`
- [ ] Run `bun run typecheck`
- [ ] Verify `app add` works with `org.create_app`
- [ ] Verify `build request` uses `app.build_native`
- [ ] Verify `bundle upload` channel updates use RBAC-aware permission checks
- [ ] Verify `init` only offers organizations with `org.create_app`
- [ ] Verify `login`, `user account`, and `organization add` still work with a valid API key

Generated with AI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Auth now derives user identity from API keys and enforces finer-grained, scoped permissions per organization/app/channel; permission checks surface clearer, silent-aware messages.

* **New Features**
  * Init now selects only organizations the API key may use for app creation; prompts updated when multiple orgs are available.
  * Uploads respect channel-aware permissions and fail fast on invalid channel lookups.

* **Improvement**
  * Build log streaming and receipt confirmations made more reliable.
* **Behavior**
  * Listings and actions now return only items accessible to the provided API key.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->