### PR TITLE
[codex] Improve onboarding recovery flows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -316,7 +316,9 @@ jobs:
         run: bun install
       - name: Install local @capgo/cli package
         working-directory: capgo
-        run: bun add -d file:..
+        run: |
+          bun remove @capgo/cli
+          bun add -d file:..
       - name: Run CLI tests
         working-directory: capgo
         run: LOCAL_CLI_PATH="../../../dist/index.js" bun run test:cli

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 - Put command implementation logic in dedicated modules/handlers instead of inline `.action(...)` bodies in `src/index.ts`.
 - When adding or changing a CLI command, prefer an exported command handler function in a dedicated module and wire it from `src/index.ts`.
 - When adding or changing a CLI command, command option, or CLI-facing workflow, update the TanStack Intent skill docs in `skills/` as part of the same change so the published skills stay aligned with `webdocs/` and `src/index.ts`.
+- For end-customer-facing docs and skills in `skills/` and `webdocs/`, use generic command runners in examples (`npx @capgo/cli@latest ...`) instead of Bun-specific runners. Reserve `bun` and `bunx` for repo-local development and agent execution.
 - Reuse shared option descriptions from `src/index.ts` when an option already exists instead of introducing slightly different wording.
 - For CLI-facing output, use `@clack/prompts` (`log`, `spinner`, `intro`, `outro`, `confirm`, `select`) to stay consistent with the rest of the CLI UX.
 - If a command may run in non-interactive mode, do not rely on spinner-only output; provide plain log output or a non-TTY fallback.

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "test:build-zip-filter": "bun test/test-build-zip-filter.mjs",
     "test:checksum": "bun test/test-checksum-algorithm.mjs",
     "test:ci-prompts": "bun test/test-ci-prompts.mjs",
+    "test:onboarding-recovery": "bun test/test-onboarding-recovery.mjs",
     "test:prompt-preferences": "bun test/test-prompt-preferences.mjs",
     "test:esm-sdk": "node test/test-sdk-esm.mjs",
     "test:mcp": "node test/test-mcp.mjs",
@@ -79,7 +80,7 @@
     "test:version-detection:setup": "./test/fixtures/setup-test-projects.sh",
     "test:platform-paths": "bun test/test-platform-paths.mjs",
     "test:payload-split": "bun test/test-payload-split.mjs",
-    "test": "bun run test:bundle && bun run test:functional && bun run test:semver && bun run test:version-edge-cases && bun run test:regex && bun run test:upload && bun run test:credentials && bun run test:credentials-validation && bun run test:build-zip-filter && bun run test:checksum && bun run test:ci-prompts && bun run test:prompt-preferences && bun run test:esm-sdk && bun run test:mcp && bun run test:version-detection && bun run test:platform-paths && bun run test:payload-split"
+    "test": "bun run test:bundle && bun run test:functional && bun run test:semver && bun run test:version-edge-cases && bun run test:regex && bun run test:upload && bun run test:credentials && bun run test:credentials-validation && bun run test:build-zip-filter && bun run test:checksum && bun run test:ci-prompts && bun run test:onboarding-recovery && bun run test:prompt-preferences && bun run test:esm-sdk && bun run test:mcp && bun run test:version-detection && bun run test:platform-paths && bun run test:payload-split"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^7.0.0",

--- a/skills/native-builds/SKILL.md
+++ b/skills/native-builds/SKILL.md
@@ -13,8 +13,8 @@ Use this skill for Capgo Cloud native iOS and Android build workflows.
 
 - Interactive command that automates iOS certificate and provisioning profile creation.
 - Reduces iOS setup from ~10 manual steps to 1 manual step (creating an API key) + 1 command.
-- Example: `npx @capgo/cli@latest build init`
-- Backward compatibility: `npx @capgo/cli@latest build onboarding` still works.
+- Example: `bunx @capgo/cli@latest build init`
+- Backward compatibility: `bunx @capgo/cli@latest build onboarding` still works.
 - Notes:
   - Uses Ink (React for terminal) for the interactive UI, alongside the main `init` onboarding flow.
   - Requires running inside a Capacitor project directory with an `ios/` folder.
@@ -24,6 +24,8 @@ Use this skill for Capgo Cloud native iOS and Android build workflows.
   - Progress persists in `~/.capgo-credentials/onboarding/<appId>.json` — safe to interrupt and resume.
   - Saves credentials to the same `~/.capgo-credentials/credentials.json` used by `build request`.
   - Optionally kicks off the first build at the end.
+  - If the native `ios/` folder is missing, onboarding can offer to run `cap add ios` automatically instead of exiting immediately.
+  - Unexpected failures now keep the user inside the recovery screen, show package-manager-aware commands, and save a support bundle under `~/.capgo-credentials/support/`.
 
 #### What it automates (iOS)
 
@@ -71,7 +73,7 @@ interface BuildLogger {
 
 ### `build request [appId]`
 
-- Example: `npx @capgo/cli@latest build request com.example.app --platform ios --path .`
+- Example: `bunx @capgo/cli@latest build request com.example.app --platform ios --path .`
 - Notes:
   - Zips the current project directory and uploads it to Capgo for building.
   - Builds are processed for store distribution.
@@ -129,7 +131,7 @@ Credentials are stored locally, either globally in `~/.capgo-credentials/credent
 - Example iOS flow:
 
 ```bash
-npx @capgo/cli build credentials save --platform ios \
+bunx @capgo/cli build credentials save --platform ios \
   --certificate ./cert.p12 --p12-password "password" \
   --ios-provisioning-profile ./profile.mobileprovision \
   --apple-key ./AuthKey.p8 --apple-key-id "KEY123" \
@@ -139,7 +141,7 @@ npx @capgo/cli build credentials save --platform ios \
 - Example multi-target iOS flow:
 
 ```bash
-npx @capgo/cli build credentials save --platform ios \
+bunx @capgo/cli build credentials save --platform ios \
   --ios-provisioning-profile ./App.mobileprovision \
   --ios-provisioning-profile com.example.widget=./Widget.mobileprovision
 ```
@@ -147,7 +149,7 @@ npx @capgo/cli build credentials save --platform ios \
 - Example Android flow:
 
 ```bash
-npx @capgo/cli build credentials save --platform android \
+bunx @capgo/cli build credentials save --platform android \
   --keystore ./release.keystore --keystore-alias "my-key" \
   --keystore-key-password "key-pass" \
   --play-config ./service-account.json
@@ -186,8 +188,8 @@ npx @capgo/cli build credentials save --platform android \
 ### `build credentials list`
 
 - Examples:
-  - `npx @capgo/cli build credentials list`
-  - `npx @capgo/cli build credentials list --appId com.example.app`
+  - `bunx @capgo/cli build credentials list`
+  - `bunx @capgo/cli build credentials list --appId com.example.app`
 - Options:
   - `--appId <appId>`
   - `--local`
@@ -195,9 +197,9 @@ npx @capgo/cli build credentials save --platform android \
 ### `build credentials clear`
 
 - Examples:
-  - `npx @capgo/cli build credentials clear`
-  - `npx @capgo/cli build credentials clear --local`
-  - `npx @capgo/cli build credentials clear --appId com.example.app --platform ios`
+  - `bunx @capgo/cli build credentials clear`
+  - `bunx @capgo/cli build credentials clear --local`
+  - `bunx @capgo/cli build credentials clear --appId com.example.app --platform ios`
 - Options:
   - `--appId <appId>`
   - `--platform <platform>`
@@ -208,8 +210,8 @@ npx @capgo/cli build credentials save --platform android \
 - Use to update specific credential fields without re-entering all data.
 - Platform is auto-detected from the supplied options.
 - Examples:
-  - `npx @capgo/cli build credentials update --ios-provisioning-profile ./new-profile.mobileprovision`
-  - `npx @capgo/cli build credentials update --local --keystore ./new-keystore.jks`
+  - `bunx @capgo/cli build credentials update --ios-provisioning-profile ./new-profile.mobileprovision`
+  - `bunx @capgo/cli build credentials update --local --keystore ./new-keystore.jks`
 - Core options:
   - `--appId <appId>`
   - `--platform <platform>`
@@ -222,7 +224,7 @@ npx @capgo/cli build credentials save --platform android \
 
 ### `build credentials migrate`
 
-- Example: `npx @capgo/cli build credentials migrate --platform ios`
+- Example: `bunx @capgo/cli build credentials migrate --platform ios`
 - Notes:
   - Converts `BUILD_PROVISION_PROFILE_BASE64` to `CAPGO_IOS_PROVISIONING_MAP`.
   - Discovers the main bundle ID from the Xcode project automatically.

--- a/skills/native-builds/SKILL.md
+++ b/skills/native-builds/SKILL.md
@@ -13,8 +13,8 @@ Use this skill for Capgo Cloud native iOS and Android build workflows.
 
 - Interactive command that automates iOS certificate and provisioning profile creation.
 - Reduces iOS setup from ~10 manual steps to 1 manual step (creating an API key) + 1 command.
-- Example: `bunx @capgo/cli@latest build init`
-- Backward compatibility: `bunx @capgo/cli@latest build onboarding` still works.
+- Example: `npx @capgo/cli@latest build init`
+- Backward compatibility: `npx @capgo/cli@latest build onboarding` still works.
 - Notes:
   - Uses Ink (React for terminal) for the interactive UI, alongside the main `init` onboarding flow.
   - Requires running inside a Capacitor project directory with an `ios/` folder.
@@ -73,7 +73,7 @@ interface BuildLogger {
 
 ### `build request [appId]`
 
-- Example: `bunx @capgo/cli@latest build request com.example.app --platform ios --path .`
+- Example: `npx @capgo/cli@latest build request com.example.app --platform ios --path .`
 - Notes:
   - Zips the current project directory and uploads it to Capgo for building.
   - Builds are processed for store distribution.
@@ -131,7 +131,7 @@ Credentials are stored locally, either globally in `~/.capgo-credentials/credent
 - Example iOS flow:
 
 ```bash
-bunx @capgo/cli build credentials save --platform ios \
+npx @capgo/cli build credentials save --platform ios \
   --certificate ./cert.p12 --p12-password "password" \
   --ios-provisioning-profile ./profile.mobileprovision \
   --apple-key ./AuthKey.p8 --apple-key-id "KEY123" \
@@ -141,7 +141,7 @@ bunx @capgo/cli build credentials save --platform ios \
 - Example multi-target iOS flow:
 
 ```bash
-bunx @capgo/cli build credentials save --platform ios \
+npx @capgo/cli build credentials save --platform ios \
   --ios-provisioning-profile ./App.mobileprovision \
   --ios-provisioning-profile com.example.widget=./Widget.mobileprovision
 ```
@@ -149,7 +149,7 @@ bunx @capgo/cli build credentials save --platform ios \
 - Example Android flow:
 
 ```bash
-bunx @capgo/cli build credentials save --platform android \
+npx @capgo/cli build credentials save --platform android \
   --keystore ./release.keystore --keystore-alias "my-key" \
   --keystore-key-password "key-pass" \
   --play-config ./service-account.json
@@ -188,8 +188,8 @@ bunx @capgo/cli build credentials save --platform android \
 ### `build credentials list`
 
 - Examples:
-  - `bunx @capgo/cli build credentials list`
-  - `bunx @capgo/cli build credentials list --appId com.example.app`
+  - `npx @capgo/cli build credentials list`
+  - `npx @capgo/cli build credentials list --appId com.example.app`
 - Options:
   - `--appId <appId>`
   - `--local`
@@ -197,9 +197,9 @@ bunx @capgo/cli build credentials save --platform android \
 ### `build credentials clear`
 
 - Examples:
-  - `bunx @capgo/cli build credentials clear`
-  - `bunx @capgo/cli build credentials clear --local`
-  - `bunx @capgo/cli build credentials clear --appId com.example.app --platform ios`
+  - `npx @capgo/cli build credentials clear`
+  - `npx @capgo/cli build credentials clear --local`
+  - `npx @capgo/cli build credentials clear --appId com.example.app --platform ios`
 - Options:
   - `--appId <appId>`
   - `--platform <platform>`
@@ -210,8 +210,8 @@ bunx @capgo/cli build credentials save --platform android \
 - Use to update specific credential fields without re-entering all data.
 - Platform is auto-detected from the supplied options.
 - Examples:
-  - `bunx @capgo/cli build credentials update --ios-provisioning-profile ./new-profile.mobileprovision`
-  - `bunx @capgo/cli build credentials update --local --keystore ./new-keystore.jks`
+  - `npx @capgo/cli build credentials update --ios-provisioning-profile ./new-profile.mobileprovision`
+  - `npx @capgo/cli build credentials update --local --keystore ./new-keystore.jks`
 - Core options:
   - `--appId <appId>`
   - `--platform <platform>`
@@ -224,7 +224,7 @@ bunx @capgo/cli build credentials save --platform android \
 
 ### `build credentials migrate`
 
-- Example: `bunx @capgo/cli build credentials migrate --platform ios`
+- Example: `npx @capgo/cli build credentials migrate --platform ios`
 - Notes:
   - Converts `BUILD_PROVISION_PROFILE_BASE64` to `CAPGO_IOS_PROVISIONING_MAP`.
   - Discovers the main bundle ID from the Xcode project automatically.

--- a/skills/usage/SKILL.md
+++ b/skills/usage/SKILL.md
@@ -16,7 +16,7 @@ TanStack Intent skills should stay focused and under the validator line limit, s
 
 ## Shared invocation rules
 
-- Prefer `bunx @capgo/cli@latest ...` in user-facing examples in this repo.
+- Prefer `npx @capgo/cli@latest ...` in user-facing examples in this repo.
 - Many commands can infer `appId` and related config from the current Capacitor project.
 - Shared public flags commonly include `-a, --apikey <apikey>` and `--verbose` on commands that support verbose output.
 
@@ -24,7 +24,7 @@ TanStack Intent skills should stay focused and under the validator line limit, s
 
 ### Project setup and diagnostics
 
-- `init [apikey] [appId]`: guided first-time setup for Capgo in a Capacitor app. The interactive flow now runs as a real Ink-based fullscreen onboarding so it uses the same UI stack as `build init` (alias: `build onboarding`), with a persistent dashboard, phase roadmap, progress cards, shared log area, and resume support. When dependency auto-detection fails on macOS, the flow opens a native file picker for `package.json` before falling back to manual path entry. If the user reuses a pending app that was already created in the web onboarding flow, the CLI syncs that selected dashboard app ID back into `capacitor.config.*` before the remaining steps continue. Outside that reused pending-app path, the CLI keeps using the local Capacitor app ID. It can also offer a final `bunx skills add https://github.com/Cap-go/capgo-skills -g -y` install step before the GitHub support prompt; if accepted, the support menu includes `Cap-go/capgo-skills` alongside the updater-only and all-Capgo choices. If native platforms are missing, the onboarding can offer to run `cap add` for you. If iOS sync validation fails during onboarding, the CLI can offer to run a one-line native reset command, wait for you to type `ready` after a manual fix, surface `doctor`, and save a support bundle before you leave the flow.
+- `init [apikey] [appId]`: guided first-time setup for Capgo in a Capacitor app. The interactive flow now runs as a real Ink-based fullscreen onboarding so it uses the same UI stack as `build init` (alias: `build onboarding`), with a persistent dashboard, phase roadmap, progress cards, shared log area, and resume support. When dependency auto-detection fails on macOS, the flow opens a native file picker for `package.json` before falling back to manual path entry. If the user reuses a pending app that was already created in the web onboarding flow, the CLI syncs that selected dashboard app ID back into `capacitor.config.*` before the remaining steps continue. Outside that reused pending-app path, the CLI keeps using the local Capacitor app ID. It can also offer a final `npx skills add https://github.com/Cap-go/capgo-skills -g -y` install step before the GitHub support prompt; if accepted, the support menu includes `Cap-go/capgo-skills` alongside the updater-only and all-Capgo choices. If native platforms are missing, the onboarding can offer to run `cap add` for you. If iOS sync validation fails during onboarding, the CLI can offer to run a one-line native reset command, wait for you to type `ready` after a manual fix, surface `doctor`, and save a support bundle before you leave the flow.
 - `login [apikey]`: store an API key locally.
 - `doctor`: inspect installation health and gather troubleshooting details.
 - `probe`: test whether the update endpoint would deliver an update.
@@ -80,10 +80,10 @@ Load `skills/organization-management/SKILL.md` when working with:
 ## Common command examples
 
 ```bash
-bunx @capgo/cli@latest init YOUR_API_KEY com.example.app
-bunx @capgo/cli@latest login YOUR_API_KEY
-bunx @capgo/cli@latest doctor
-bunx @capgo/cli@latest probe --platform ios
-bunx @capgo/cli@latest app add com.example.app --name "My App"
-bunx @capgo/cli@latest star-all
+npx @capgo/cli@latest init YOUR_API_KEY com.example.app
+npx @capgo/cli@latest login YOUR_API_KEY
+npx @capgo/cli@latest doctor
+npx @capgo/cli@latest probe --platform ios
+npx @capgo/cli@latest app add com.example.app --name "My App"
+npx @capgo/cli@latest star-all
 ```

--- a/skills/usage/SKILL.md
+++ b/skills/usage/SKILL.md
@@ -16,7 +16,7 @@ TanStack Intent skills should stay focused and under the validator line limit, s
 
 ## Shared invocation rules
 
-- Prefer `npx @capgo/cli@latest ...` in user-facing examples to match existing docs and CLI output.
+- Prefer `bunx @capgo/cli@latest ...` in user-facing examples in this repo.
 - Many commands can infer `appId` and related config from the current Capacitor project.
 - Shared public flags commonly include `-a, --apikey <apikey>` and `--verbose` on commands that support verbose output.
 
@@ -24,7 +24,7 @@ TanStack Intent skills should stay focused and under the validator line limit, s
 
 ### Project setup and diagnostics
 
-- `init [apikey] [appId]`: guided first-time setup for Capgo in a Capacitor app. The interactive flow now runs as a real Ink-based fullscreen onboarding so it uses the same UI stack as `build init` (alias: `build onboarding`), with a persistent dashboard, phase roadmap, progress cards, shared log area, and resume support. When dependency auto-detection fails on macOS, the flow opens a native file picker for `package.json` before falling back to manual path entry. If the user reuses a pending app that was already created in the web onboarding flow, the CLI syncs that selected dashboard app ID back into `capacitor.config.*` before the remaining steps continue. Outside that reused pending-app path, the CLI keeps using the local Capacitor app ID. It can also offer a final `npx skills add https://github.com/Cap-go/capgo-skills -g -y` install step before the GitHub support prompt; if accepted, the support menu includes `Cap-go/capgo-skills` alongside the updater-only and all-Capgo choices. If iOS sync validation fails during onboarding, the CLI can offer to run a one-line native reset command, wait for you to type `ready` after a manual fix, and offer cancellation every third failed retry.
+- `init [apikey] [appId]`: guided first-time setup for Capgo in a Capacitor app. The interactive flow now runs as a real Ink-based fullscreen onboarding so it uses the same UI stack as `build init` (alias: `build onboarding`), with a persistent dashboard, phase roadmap, progress cards, shared log area, and resume support. When dependency auto-detection fails on macOS, the flow opens a native file picker for `package.json` before falling back to manual path entry. If the user reuses a pending app that was already created in the web onboarding flow, the CLI syncs that selected dashboard app ID back into `capacitor.config.*` before the remaining steps continue. Outside that reused pending-app path, the CLI keeps using the local Capacitor app ID. It can also offer a final `bunx skills add https://github.com/Cap-go/capgo-skills -g -y` install step before the GitHub support prompt; if accepted, the support menu includes `Cap-go/capgo-skills` alongside the updater-only and all-Capgo choices. If native platforms are missing, the onboarding can offer to run `cap add` for you. If iOS sync validation fails during onboarding, the CLI can offer to run a one-line native reset command, wait for you to type `ready` after a manual fix, surface `doctor`, and save a support bundle before you leave the flow.
 - `login [apikey]`: store an API key locally.
 - `doctor`: inspect installation health and gather troubleshooting details.
 - `probe`: test whether the update endpoint would deliver an update.
@@ -80,10 +80,10 @@ Load `skills/organization-management/SKILL.md` when working with:
 ## Common command examples
 
 ```bash
-npx @capgo/cli@latest init YOUR_API_KEY com.example.app
-npx @capgo/cli@latest login YOUR_API_KEY
-npx @capgo/cli@latest doctor
-npx @capgo/cli@latest probe --platform ios
-npx @capgo/cli@latest app add com.example.app --name "My App"
-npx @capgo/cli@latest star-all
+bunx @capgo/cli@latest init YOUR_API_KEY com.example.app
+bunx @capgo/cli@latest login YOUR_API_KEY
+bunx @capgo/cli@latest doctor
+bunx @capgo/cli@latest probe --platform ios
+bunx @capgo/cli@latest app add com.example.app --name "My App"
+bunx @capgo/cli@latest star-all
 ```

--- a/src/build/onboarding/recovery.ts
+++ b/src/build/onboarding/recovery.ts
@@ -1,0 +1,101 @@
+import type { OnboardingStep } from './types.js'
+import { formatRunnerCommand } from '../../runner-command.js'
+
+export interface BuildOnboardingRecoveryAdvice {
+  summary: string[]
+  commands: string[]
+  docs: string[]
+}
+
+export function getBuildOnboardingRecoveryAdvice(
+  message: string,
+  step: OnboardingStep | null,
+  pmRunner: string,
+  appId: string,
+): BuildOnboardingRecoveryAdvice {
+  const lower = message.toLowerCase()
+  const summary: string[] = []
+  const commands = new Set<string>()
+  const docs = new Set<string>()
+
+  const addIosCommand = formatRunnerCommand(pmRunner, ['cap', 'add', 'ios'])
+  const syncIosCommand = formatRunnerCommand(pmRunner, ['cap', 'sync', 'ios'])
+  const doctorCommand = formatRunnerCommand(pmRunner, ['@capgo/cli@latest', 'doctor'])
+  const buildInitCommand = formatRunnerCommand(pmRunner, ['@capgo/cli@latest', 'build', 'init'])
+  const buildRequestCommand = formatRunnerCommand(pmRunner, ['@capgo/cli@latest', 'build', 'request', appId, '--platform', 'ios'])
+  const loginCommand = formatRunnerCommand(pmRunner, ['@capgo/cli@latest', 'login'])
+
+  if (step === 'no-platform' || step === 'adding-platform' || lower.includes('no ios/ directory')) {
+    summary.push('This project does not have a generated native iOS folder yet.')
+    summary.push('Create the iOS platform, then sync native sources before resuming onboarding.')
+    commands.add(addIosCommand)
+    commands.add(syncIosCommand)
+  }
+
+  if (lower.includes('api key verification failed') || lower.includes('401') || lower.includes('403')) {
+    summary.push('Apple rejected the App Store Connect credentials.')
+    summary.push('Double-check the .p8 file, Key ID, Issuer ID, and that the key still has Admin or Developer access.')
+    docs.add('https://capgo.app/docs/cli/cloud-build/ios/')
+    docs.add('https://appstoreconnect.apple.com/access/integrations/api')
+  }
+
+  if (lower.includes('fetch failed') || lower.includes('network') || lower.includes('etimedout') || lower.includes('enotfound') || lower.includes('econnreset')) {
+    summary.push('The CLI could not reach Apple or Capgo over the network.')
+    summary.push('Check VPN, proxy, firewall, and DNS settings, then retry from the saved step.')
+    commands.add(doctorCommand)
+  }
+
+  if (lower.includes('429') || lower.includes('rate limit')) {
+    summary.push('Apple is rate-limiting the request right now.')
+    summary.push('Wait a minute, then retry from the saved step instead of restarting the whole flow.')
+  }
+
+  if (lower.includes('certificate limit')) {
+    summary.push('Apple has reached the maximum number of active distribution certificates for this team.')
+  }
+
+  if (lower.includes('duplicate profile')) {
+    summary.push('Apple still has conflicting provisioning profiles for this bundle identifier.')
+    summary.push('You can let onboarding delete the duplicates automatically, or clean them up in App Store Connect and resume.')
+    docs.add('https://appstoreconnect.apple.com/access/users')
+  }
+
+  if (lower.includes('bundle') && lower.includes('identifier')) {
+    summary.push('Apple reported a bundle identifier conflict or bundle registration issue.')
+    summary.push(`Verify that ${appId} is the bundle ID you intend to build for in both Capgo and your Capacitor config.`)
+    commands.add(doctorCommand)
+  }
+
+  if (lower.includes('file not found') || lower.includes('could not read file') || lower.includes('need .p8 file')) {
+    summary.push('The onboarding flow could not read the API key file from disk.')
+    summary.push('Re-select the .p8 file or move it somewhere stable before retrying.')
+  }
+
+  if (lower.includes('no capgo api key found')) {
+    summary.push('Capgo login is missing, so the first cloud build cannot be requested automatically.')
+    commands.add(loginCommand)
+    commands.add(buildRequestCommand)
+  }
+
+  if (lower.includes('credentials are saved')) {
+    summary.push('Your signing material is already saved locally, so you only need to re-run the build request.')
+    commands.add(buildRequestCommand)
+  }
+
+  if (summary.length === 0) {
+    summary.push('The onboarding flow hit an unexpected error.')
+    summary.push('Retry the saved step first. If it still fails, capture diagnostics and keep the support bundle when you contact support.')
+    commands.add(doctorCommand)
+    commands.add(buildInitCommand)
+    docs.add('https://capgo.app/docs/cli/cloud-build/ios/')
+  }
+  else {
+    commands.add(buildInitCommand)
+  }
+
+  return {
+    summary,
+    commands: Array.from(commands),
+    docs: Array.from(docs),
+  }
+}

--- a/src/build/onboarding/recovery.ts
+++ b/src/build/onboarding/recovery.ts
@@ -26,28 +26,36 @@ export function getBuildOnboardingRecoveryAdvice(
   const loginCommand = formatRunnerCommand(pmRunner, ['@capgo/cli@latest', 'login'])
 
   if (step === 'no-platform' || step === 'adding-platform' || lower.includes('no ios/ directory')) {
-    summary.push('This project does not have a generated native iOS folder yet.')
-    summary.push('Create the iOS platform, then sync native sources before resuming onboarding.')
+    summary.push(
+      'This project does not have a generated native iOS folder yet.',
+      'Create the iOS platform, then sync native sources before resuming onboarding.',
+    )
     commands.add(addIosCommand)
     commands.add(syncIosCommand)
   }
 
   if (lower.includes('api key verification failed') || lower.includes('401') || lower.includes('403')) {
-    summary.push('Apple rejected the App Store Connect credentials.')
-    summary.push('Double-check the .p8 file, Key ID, Issuer ID, and that the key still has Admin or Developer access.')
+    summary.push(
+      'Apple rejected the App Store Connect credentials.',
+      'Double-check the .p8 file, Key ID, Issuer ID, and that the key still has Admin or Developer access.',
+    )
     docs.add('https://capgo.app/docs/cli/cloud-build/ios/')
     docs.add('https://appstoreconnect.apple.com/access/integrations/api')
   }
 
   if (lower.includes('fetch failed') || lower.includes('network') || lower.includes('etimedout') || lower.includes('enotfound') || lower.includes('econnreset')) {
-    summary.push('The CLI could not reach Apple or Capgo over the network.')
-    summary.push('Check VPN, proxy, firewall, and DNS settings, then retry from the saved step.')
+    summary.push(
+      'The CLI could not reach Apple or Capgo over the network.',
+      'Check VPN, proxy, firewall, and DNS settings, then retry from the saved step.',
+    )
     commands.add(doctorCommand)
   }
 
   if (lower.includes('429') || lower.includes('rate limit')) {
-    summary.push('Apple is rate-limiting the request right now.')
-    summary.push('Wait a minute, then retry from the saved step instead of restarting the whole flow.')
+    summary.push(
+      'Apple is rate-limiting the request right now.',
+      'Wait a minute, then retry from the saved step instead of restarting the whole flow.',
+    )
   }
 
   if (lower.includes('certificate limit')) {
@@ -55,20 +63,26 @@ export function getBuildOnboardingRecoveryAdvice(
   }
 
   if (lower.includes('duplicate profile')) {
-    summary.push('Apple still has conflicting provisioning profiles for this bundle identifier.')
-    summary.push('You can let onboarding delete the duplicates automatically, or clean them up in App Store Connect and resume.')
+    summary.push(
+      'Apple still has conflicting provisioning profiles for this bundle identifier.',
+      'You can let onboarding delete the duplicates automatically, or clean them up in App Store Connect and resume.',
+    )
     docs.add('https://appstoreconnect.apple.com/access/users')
   }
 
   if (lower.includes('bundle') && lower.includes('identifier')) {
-    summary.push('Apple reported a bundle identifier conflict or bundle registration issue.')
-    summary.push(`Verify that ${appId} is the bundle ID you intend to build for in both Capgo and your Capacitor config.`)
+    summary.push(
+      'Apple reported a bundle identifier conflict or bundle registration issue.',
+      `Verify that ${appId} is the bundle ID you intend to build for in both Capgo and your Capacitor config.`,
+    )
     commands.add(doctorCommand)
   }
 
   if (lower.includes('file not found') || lower.includes('could not read file') || lower.includes('need .p8 file')) {
-    summary.push('The onboarding flow could not read the API key file from disk.')
-    summary.push('Re-select the .p8 file or move it somewhere stable before retrying.')
+    summary.push(
+      'The onboarding flow could not read the API key file from disk.',
+      'Re-select the .p8 file or move it somewhere stable before retrying.',
+    )
   }
 
   if (lower.includes('no capgo api key found')) {
@@ -83,8 +97,10 @@ export function getBuildOnboardingRecoveryAdvice(
   }
 
   if (summary.length === 0) {
-    summary.push('The onboarding flow hit an unexpected error.')
-    summary.push('Retry the saved step first. If it still fails, capture diagnostics and keep the support bundle when you contact support.')
+    summary.push(
+      'The onboarding flow hit an unexpected error.',
+      'Retry the saved step first. If it still fails, capture diagnostics and keep the support bundle when you contact support.',
+    )
     commands.add(doctorCommand)
     commands.add(buildInitCommand)
     docs.add('https://capgo.app/docs/cli/cloud-build/ios/')

--- a/src/build/onboarding/types.ts
+++ b/src/build/onboarding/types.ts
@@ -5,6 +5,7 @@ export type Platform = 'ios' | 'android'
 export type OnboardingStep
   = | 'welcome'
     | 'platform-select'
+    | 'adding-platform'
     | 'credentials-exist'
     | 'backing-up'
     | 'api-key-instructions'
@@ -66,6 +67,7 @@ export interface OnboardingProgress {
 export const STEP_PROGRESS: Record<OnboardingStep, number> = {
   'welcome': 0,
   'platform-select': 0,
+  'adding-platform': 0,
   'credentials-exist': 0,
   'backing-up': 0,
   'api-key-instructions': 5,
@@ -92,6 +94,7 @@ export function getPhaseLabel(step: OnboardingStep): string {
   switch (step) {
     case 'welcome':
     case 'platform-select':
+    case 'adding-platform':
     case 'credentials-exist':
     case 'backing-up':
       return ''

--- a/src/build/onboarding/ui/app.tsx
+++ b/src/build/onboarding/ui/app.tsx
@@ -1232,8 +1232,8 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir }) => {
             <>
               <Text bold>Recovery plan</Text>
               <Box flexDirection="column" marginTop={1} marginLeft={2}>
-                {recoveryAdvice.summary.map((line, index) => (
-                  <Text key={`recovery-summary-${index}`}>{`• ${line}`}</Text>
+                {recoveryAdvice.summary.map(line => (
+                  <Text key={`recovery-summary-${line}`}>{`• ${line}`}</Text>
                 ))}
               </Box>
               {recoveryAdvice.commands.length > 0 && (
@@ -1241,8 +1241,8 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir }) => {
                   <Newline />
                   <Text bold>Helpful commands</Text>
                   <Box flexDirection="column" marginTop={1} marginLeft={2}>
-                    {recoveryAdvice.commands.map((command, index) => (
-                      <Text key={`recovery-command-${index}`} dimColor>{command}</Text>
+                    {recoveryAdvice.commands.map(command => (
+                      <Text key={`recovery-command-${command}`} dimColor>{command}</Text>
                     ))}
                   </Box>
                 </>
@@ -1252,8 +1252,8 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir }) => {
                   <Newline />
                   <Text bold>Docs</Text>
                   <Box flexDirection="column" marginTop={1} marginLeft={2}>
-                    {recoveryAdvice.docs.map((doc, index) => (
-                      <Text key={`recovery-doc-${index}`} color="cyan">{doc}</Text>
+                    {recoveryAdvice.docs.map(doc => (
+                      <Text key={`recovery-doc-${doc}`} color="cyan">{doc}</Text>
                     ))}
                   </Box>
                 </>

--- a/src/build/onboarding/ui/app.tsx
+++ b/src/build/onboarding/ui/app.tsx
@@ -2,6 +2,7 @@ import type { FC } from 'react'
 import type { BuildLogger } from '../../request.js'
 import type { ApiKeyData, CertificateData, OnboardingProgress, OnboardingStep, ProfileData } from '../types.js'
 import { handleCustomMsg } from '../../qr.js'
+import { spawn } from 'node:child_process'
 import { Buffer } from 'node:buffer'
 import { existsSync } from 'node:fs'
 import { copyFile, readFile } from 'node:fs/promises'
@@ -13,13 +14,16 @@ import { Box, Newline, Text, useApp, useInput, useStdout } from 'ink'
 import open from 'open'
 // src/build/onboarding/ui/app.tsx
 import React, { useCallback, useEffect, useRef, useState } from 'react'
-import { findSavedKey } from '../../../utils.js'
+import { writeOnboardingSupportBundle } from '../../../onboarding-support.js'
+import { formatRunnerCommand, splitRunnerCommand } from '../../../runner-command.js'
+import { findSavedKey, getPMAndCommand } from '../../../utils.js'
 import { loadSavedCredentials, updateSavedCredentials } from '../../credentials.js'
 import { requestBuildInternal } from '../../request.js'
 import { CertificateLimitError, createCertificate, createProfile, deleteProfile, DuplicateProfileError, ensureBundleId, generateJwt, revokeCertificate, verifyApiKey } from '../apple-api.js'
 import { createP12, DEFAULT_P12_PASSWORD, generateCsr } from '../csr.js'
 import { canUseFilePicker, openFilePicker } from '../file-picker.js'
 import { deleteProgress, getResumeStep, loadProgress, saveProgress } from '../progress.js'
+import { getBuildOnboardingRecoveryAdvice } from '../recovery.js'
 import {
   getPhaseLabel,
 
@@ -34,6 +38,36 @@ interface AppProps {
   initialProgress: OnboardingProgress | null
   /** Resolved iOS directory from capacitor.config (defaults to 'ios') */
   iosDir: string
+}
+
+async function runRunnerCommand(runner: string, args: string[]): Promise<{ success: boolean, output: string[] }> {
+  const { command, args: runnerArgs } = splitRunnerCommand(runner)
+
+  return new Promise((resolve) => {
+    const child = spawn(command, [...runnerArgs, ...args], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    const output: string[] = []
+
+    const append = (chunk: Buffer | string) => {
+      const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8')
+      for (const rawLine of text.split(/\r?\n/)) {
+        const line = rawLine.replace(/\r/g, '').trim()
+        if (line)
+          output.push(line)
+      }
+    }
+
+    child.stdout?.on('data', append)
+    child.stderr?.on('data', append)
+    child.once('error', (error) => {
+      output.push(error.message)
+      resolve({ success: false, output })
+    })
+    child.once('close', (code) => {
+      resolve({ success: code === 0, output })
+    })
+  })
 }
 
 const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir }) => {
@@ -90,10 +124,19 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir }) => {
   const [profileData, setProfileData] = useState<ProfileData | null>(initialProgress?.completedSteps.profileCreated || null)
   const [buildUrl, setBuildUrl] = useState('')
   const [buildOutput, setBuildOutput] = useState<string[]>([])
+  const [supportBundlePath, setSupportBundlePath] = useState<string | null>(null)
 
   const addLog = useCallback((text: string, color = 'green') => {
     setLog(prev => [...prev, { text, color }])
   }, [])
+
+  const pm = getPMAndCommand()
+  const addIosCommand = formatRunnerCommand(pm.runner, ['cap', 'add', 'ios'])
+  const syncIosCommand = formatRunnerCommand(pm.runner, ['cap', 'sync', 'ios'])
+  const doctorCommand = formatRunnerCommand(pm.runner, ['@capgo/cli@latest', 'doctor'])
+  const buildInitCommand = formatRunnerCommand(pm.runner, ['@capgo/cli@latest', 'build', 'init'])
+  const buildRequestCommand = formatRunnerCommand(pm.runner, ['@capgo/cli@latest', 'build', 'request', appId, '--platform', 'ios'])
+  const loginCommand = formatRunnerCommand(pm.runner, ['@capgo/cli@latest', 'login'])
 
   const exitOnboarding = useCallback((message?: string) => {
     if (exitRequestedRef.current)
@@ -200,19 +243,30 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir }) => {
       return
     }
     const message = err instanceof Error ? err.message : String(err)
-    if (retryCount === 0) {
-      setError(message)
-      setRetryStep(failedStep)
-      setRetryCount(1)
-      setStep('error')
+    const nextRetryCount = retryCount + 1
+    const bundlePath = writeOnboardingSupportBundle({
+      kind: 'build-init',
+      appId,
+      currentStep: failedStep,
+      packageManager: pm.pm,
+      cwd: process.cwd(),
+      error: message,
+      commands: [buildInitCommand, doctorCommand],
+      docs: ['https://capgo.app/docs/cli/cloud-build/ios/'],
+      logs: [
+        ...log.slice(-12).map(entry => entry.text),
+        ...buildOutput.slice(-12),
+      ],
+    })
+    setSupportBundlePath(bundlePath)
+    setError(message)
+    setRetryStep(failedStep)
+    setRetryCount(nextRetryCount)
+    if (nextRetryCount > 1) {
+      addLog(`⚠ Attempt ${nextRetryCount} failed. Recovery steps and a support bundle are available below.`, 'yellow')
     }
-    else {
-      // Second failure — exit
-      addLog(`✖ ${message}`, 'red')
-      addLog('Run `capgo build init` to retry from where you left off.', 'yellow')
-      setTimeout(() => exitOnboarding(), 100)
-    }
-  }, [retryCount, addLog, exitOnboarding])
+    setStep('error')
+  }, [retryCount, addLog, appId, buildInitCommand, buildOutput, doctorCommand, log, pm.pm])
 
   // ── Credential save logic ──
 
@@ -291,10 +345,28 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir }) => {
     }
 
     if (step === 'no-platform') {
-      setTimeout(() => {
-        if (!cancelled)
-          exit()
-      }, 2000)
+      pickerOpenedRef.current = false
+    }
+
+    if (step === 'adding-platform') {
+      ;(async () => {
+        const result = await runRunnerCommand(pm.runner, ['cap', 'add', 'ios'])
+        if (cancelled)
+          return
+
+        if (result.success && existsSync(join(process.cwd(), iosDir))) {
+          addLog(`✔ Native iOS platform created with ${addIosCommand}`)
+          setError(null)
+          setRetryCount(0)
+          setStep('platform-select')
+          return
+        }
+
+        const detail = result.output.length > 0
+          ? `\n${result.output.slice(-6).join('\n')}`
+          : ''
+        handleError(new Error(`Could not add the iOS platform automatically.${detail}`), 'adding-platform')
+      })()
     }
 
     if (step === 'p8-method-select' && !pickerOpenedRef.current) {
@@ -325,9 +397,7 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir }) => {
         catch (err) {
           if (cancelled)
             return
-          setError(`Could not read file: ${err instanceof Error ? err.message : String(err)}`)
-          setRetryStep('api-key-instructions')
-          setStep('error')
+          handleError(new Error(`Could not read file: ${err instanceof Error ? err.message : String(err)}`), 'api-key-instructions')
         }
       })()
     }
@@ -519,7 +589,7 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir }) => {
           }
           if (!capgoKey) {
             setBuildOutput(prev => [...prev, '⚠ No Capgo API key found.'])
-            setBuildOutput(prev => [...prev, 'Run `capgo login` first, then `capgo build request`.'])
+            setBuildOutput(prev => [...prev, `Run \`${loginCommand}\` first, then \`${buildRequestCommand}\`.`])
             setStep('build-complete')
             return
           }
@@ -574,7 +644,7 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir }) => {
           // Build failure is non-fatal — credentials are saved
           if (!cancelled) {
             setBuildOutput(prev => [...prev, `⚠ ${err instanceof Error ? err.message : String(err)}`])
-            setBuildOutput(prev => [...prev, 'Your credentials are saved. Run `npx @capgo/cli@latest build request --platform ios` to try again.'])
+            setBuildOutput(prev => [...prev, `Your credentials are saved. Run \`${buildRequestCommand}\` to try again.`])
             setStep('build-complete')
           }
         }
@@ -603,9 +673,12 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir }) => {
 
   const progress = STEP_PROGRESS[step] ?? 0
   const phaseLabel = getPhaseLabel(step)
-  const showProgress = step !== 'welcome' && step !== 'platform-select' && step !== 'error' && step !== 'build-complete' && step !== 'requesting-build'
+  const showProgress = step !== 'welcome' && step !== 'platform-select' && step !== 'adding-platform' && step !== 'no-platform' && step !== 'error' && step !== 'build-complete' && step !== 'requesting-build'
   const showHeader = step !== 'requesting-build'
   const showLog = step !== 'requesting-build' && step !== 'build-complete'
+  const recoveryAdvice = error
+    ? getBuildOnboardingRecoveryAdvice(error, retryStep, pm.runner, appId)
+    : null
 
   return (
     <Box flexDirection="column" padding={1}>
@@ -678,14 +751,44 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir }) => {
       {/* No platform directory */}
       {step === 'no-platform' && (
         <Box flexDirection="column" marginTop={1}>
-          <ErrorLine text="No ios/ directory found." />
+          <ErrorLine text={`No ${iosDir}/ directory found.`} />
           <Newline />
-          <Text>
-            Run
-            <Text bold color="white">npx cap add ios</Text>
-            {' '}
-            first, then re-run onboarding.
-          </Text>
+          <Text>This onboarding flow needs a generated native iOS project before credentials can be created.</Text>
+          <Newline />
+          <Text dimColor>{`Suggested commands: ${addIosCommand} && ${syncIosCommand}`}</Text>
+          <Newline />
+          <Select
+            options={[
+              { label: `🛠  Run ${addIosCommand} now`, value: 'run' },
+              { label: '🔄  I already fixed it, re-check', value: 'recheck' },
+              { label: '✖  Exit onboarding', value: 'exit' },
+            ]}
+            onChange={(value) => {
+              if (value === 'run') {
+                setStep('adding-platform')
+              }
+              else if (value === 'recheck') {
+                if (existsSync(join(process.cwd(), iosDir))) {
+                  addLog(`✔ Found ${iosDir}/ — resuming onboarding.`)
+                  setStep('platform-select')
+                }
+                else {
+                  addLog(`⚠ ${iosDir}/ is still missing. Try ${addIosCommand} or ${doctorCommand}.`, 'yellow')
+                }
+              }
+              else {
+                addLog(`Exiting. Run \`${buildInitCommand}\` after the native iOS folder exists.`, 'yellow')
+                exitOnboarding()
+              }
+            }}
+          />
+        </Box>
+      )}
+
+      {step === 'adding-platform' && (
+        <Box flexDirection="column" marginTop={1}>
+          <SpinnerLine text={`Running ${addIosCommand}...`} />
+          <Text dimColor>{`If this still fails, try ${doctorCommand} and keep the support bundle path from the error screen.`}</Text>
         </Box>
       )}
 
@@ -816,9 +919,7 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir }) => {
                       setStep('input-key-id')
                     }
                     catch {
-                      setError(`File not found: ${filePath}`)
-                      setRetryStep('api-key-instructions')
-                      setStep('error')
+                      handleError(new Error(`File not found: ${filePath}`), 'api-key-instructions')
                     }
                   }}
                 />
@@ -856,9 +957,7 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir }) => {
                   setStep('input-key-id')
                 }
                 catch {
-                  setError(`File not found: ${value}`)
-                  setRetryStep('input-p8-path')
-                  setStep('error')
+                  handleError(new Error(`File not found: ${value}`), 'input-p8-path')
                 }
               }}
             />
@@ -990,7 +1089,7 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir }) => {
             ]}
             onChange={(value) => {
               if (value === '__exit__') {
-                addLog('Exiting. Revoke a certificate manually, then re-run onboarding.', 'yellow')
+                addLog(`Exiting. Revoke a certificate manually in App Store Connect, then resume with ${buildInitCommand}.`, 'yellow')
                 exitOnboarding()
               }
               else {
@@ -1035,7 +1134,7 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir }) => {
                 setStep('deleting-duplicate-profiles')
               }
               else {
-                addLog('Exiting. Delete duplicate profiles manually in the Apple Developer Portal, then re-run onboarding.', 'yellow')
+                addLog(`Exiting. Delete the duplicate profiles in App Store Connect, then resume with ${buildInitCommand}.`, 'yellow')
                 exitOnboarding()
               }
             }}
@@ -1119,7 +1218,47 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir }) => {
         <Box flexDirection="column" marginTop={1}>
           <ErrorLine text={error} />
           <Newline />
-          {retryCount <= 1 && retryStep && (
+          {recoveryAdvice && (
+            <>
+              <Text bold>Recovery plan</Text>
+              <Box flexDirection="column" marginTop={1} marginLeft={2}>
+                {recoveryAdvice.summary.map((line, index) => (
+                  <Text key={`recovery-summary-${index}`}>{`• ${line}`}</Text>
+                ))}
+              </Box>
+              {recoveryAdvice.commands.length > 0 && (
+                <>
+                  <Newline />
+                  <Text bold>Helpful commands</Text>
+                  <Box flexDirection="column" marginTop={1} marginLeft={2}>
+                    {recoveryAdvice.commands.map((command, index) => (
+                      <Text key={`recovery-command-${index}`} dimColor>{command}</Text>
+                    ))}
+                  </Box>
+                </>
+              )}
+              {recoveryAdvice.docs.length > 0 && (
+                <>
+                  <Newline />
+                  <Text bold>Docs</Text>
+                  <Box flexDirection="column" marginTop={1} marginLeft={2}>
+                    {recoveryAdvice.docs.map((doc, index) => (
+                      <Text key={`recovery-doc-${index}`} color="cyan">{doc}</Text>
+                    ))}
+                  </Box>
+                </>
+              )}
+            </>
+          )}
+          {supportBundlePath && (
+            <>
+              <Newline />
+              <Text bold>Support bundle</Text>
+              <Text dimColor>{supportBundlePath}</Text>
+            </>
+          )}
+          <Newline />
+          {retryStep && (
             <>
               <Text bold>What do you want to do?</Text>
               <Newline />
@@ -1139,10 +1278,11 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir }) => {
                     setError(null)
                     setRetryCount(0)
                     pickerOpenedRef.current = false
+                    setSupportBundlePath(null)
                     setStep('welcome')
                   }
                   else {
-                    setError('Run `capgo build init` to resume.')
+                    setError(`Run \`${buildInitCommand}\` to resume.`)
                     exitOnboarding()
                   }
                 }}
@@ -1185,7 +1325,7 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir }) => {
             <Text dimColor>
               Run
               {' '}
-              <Text bold color="white">npx @capgo/cli@latest build request --platform ios</Text>
+              <Text bold color="white">{buildRequestCommand}</Text>
               {' '}
               anytime to start a build.
             </Text>

--- a/src/build/onboarding/ui/app.tsx
+++ b/src/build/onboarding/ui/app.tsx
@@ -31,6 +31,9 @@ import {
 } from '../types.js'
 import { Divider, ErrorLine, FilteredTextInput, Header, SpinnerLine, SuccessLine } from './components.js'
 
+const OUTPUT_LINE_SPLIT_RE = /\r?\n/
+const CARRIAGE_RETURN_RE = /\r/g
+
 interface LogEntry { text: string, color?: string }
 
 interface AppProps {
@@ -41,7 +44,14 @@ interface AppProps {
 }
 
 async function runRunnerCommand(runner: string, args: string[]): Promise<{ success: boolean, output: string[] }> {
-  const { command, args: runnerArgs } = splitRunnerCommand(runner)
+  let command = runner
+  let runnerArgs: string[] = []
+  try {
+    ({ command, args: runnerArgs } = splitRunnerCommand(runner))
+  }
+  catch (error) {
+    return { success: false, output: [error instanceof Error ? error.message : String(error)] }
+  }
 
   return new Promise((resolve) => {
     const child = spawn(command, [...runnerArgs, ...args], {
@@ -51,8 +61,8 @@ async function runRunnerCommand(runner: string, args: string[]): Promise<{ succe
 
     const append = (chunk: Buffer | string) => {
       const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8')
-      for (const rawLine of text.split(/\r?\n/)) {
-        const line = rawLine.replace(/\r/g, '').trim()
+      for (const rawLine of text.split(OUTPUT_LINE_SPLIT_RE)) {
+        const line = rawLine.replaceAll(CARRIAGE_RETURN_RE, '').trim()
         if (line)
           output.push(line)
       }

--- a/src/init/command.ts
+++ b/src/init/command.ts
@@ -374,7 +374,7 @@ async function waitUntilSetupIsDone(message = 'Type "ready" when the setup is do
       },
     })
     cancelBeforeAuthenticatedOnboarding(ready)
-    if ((ready as string).trim().toLowerCase() === 'ready')
+    if (typeof ready === 'string' && ready.trim().toLowerCase() === 'ready')
       return
   }
 }

--- a/src/init/command.ts
+++ b/src/init/command.ts
@@ -5,7 +5,7 @@ import type { InitCodeDiff, InitEncryptionPhase, InitEncryptionSummary } from '.
 import { execSync, spawn, spawnSync } from 'node:child_process'
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs'
 import path, { dirname, join } from 'node:path'
-import { cwd, env, exit, platform, stdin, stdout } from 'node:process'
+import { chdir, cwd, env, exit, platform, stdin, stdout } from 'node:process'
 import { canParse, format, increment, lessThan, parse } from '@std/semver'
 import open from 'open'
 import tmp from 'tmp'
@@ -13,6 +13,7 @@ import { checkAppIdsExist, completePendingOnboardingApp, listPendingOnboardingAp
 import { checkVersionStatus } from '../api/update'
 import { addAppInternal } from '../app/add'
 import { markSnag, waitLog } from '../app/debug'
+import { getInfoInternal } from '../app/info'
 import { canUseFilePicker, openPackageJsonPicker } from '../build/onboarding/file-picker'
 import { getPlatformDirFromCapacitorConfig } from '../build/platform-paths'
 import { uploadBundleInternal } from '../bundle/upload'
@@ -21,7 +22,9 @@ import { writeConfigUpdater } from '../config'
 import { getRepoStarStatus, isRepoStarredInSession, starAllRepositories, starRepository } from '../github'
 import { createKeyInternal } from '../key'
 import { doLoginExists, loginInternal } from '../login'
+import { writeOnboardingSupportBundle } from '../onboarding-support'
 import { showReplicationProgress } from '../replicationProgress'
+import { formatRunnerCommand } from '../runner-command'
 import { createSupabaseClient, findBuildCommandForProjectType, findMainFile, findMainFileForProjectType, findProjectType, findRoot, findSavedKey, formatError, getAllPackagesDependencies, getAppId, getBundleVersion, getConfig, getInstalledVersion, getLocalConfig, getNativeProjectResetAdvice, getPackageScripts, getPMAndCommand, PACKNAME, projectIsMonorepo, updateConfigbyKey, updateConfigUpdater, validateIosUpdaterSync, verifyUser } from '../utils'
 import { cancel as pCancel, confirm as pConfirm, intro as pIntro, isCancel as pIsCancel, log as pLog, outro as pOutro, select as pSelect, spinner as pSpinner, text as pText } from './prompts'
 import { appendInitStreamingLine, clearInitStreamingOutput, setInitCodeDiff, setInitEncryptionSummary, setInitVersionWarning, startInitStreamingOutput, stopInitInkSession, updateInitStreamingStatus } from './runtime'
@@ -57,8 +60,54 @@ let globalCurrentVersion: string | undefined
 let globalAppId: string | undefined
 let globalCodeDiff: InitCodeDiff | undefined
 let globalEncryptionSummary: InitEncryptionSummary | undefined
+let globalCurrentStepNumber = 0
 
 const CODE_DIFF_CONTEXT_LINES = 5
+
+function getInitRecoveryCommands() {
+  const pm = getPMAndCommand()
+  return {
+    pm,
+    doctor: formatRunnerCommand(pm.runner, ['@capgo/cli@latest', 'doctor']),
+    buildInit: formatRunnerCommand(pm.runner, ['@capgo/cli@latest', 'build', 'init']),
+    capAddIos: formatRunnerCommand(pm.runner, ['cap', 'add', 'ios']),
+    capAddAndroid: formatRunnerCommand(pm.runner, ['cap', 'add', 'android']),
+    capSyncIos: formatRunnerCommand(pm.runner, ['cap', 'sync', 'ios']),
+    capSyncAndroid: formatRunnerCommand(pm.runner, ['cap', 'sync', 'android']),
+  }
+}
+
+function writeInitSupportBundle(error: string, extraSections: { title: string, lines: string[] }[] = []) {
+  const currentStep = globalCurrentStepNumber > 0
+    ? `Step ${globalCurrentStepNumber}/${initOnboardingSteps.length} · ${initOnboardingSteps[globalCurrentStepNumber - 1]?.title ?? 'Unknown step'}`
+    : undefined
+  const { pm, doctor, capAddIos, capAddAndroid } = getInitRecoveryCommands()
+
+  return writeOnboardingSupportBundle({
+    kind: 'init',
+    appId: globalAppId,
+    currentStep,
+    packageManager: pm.pm,
+    cwd: cwd(),
+    error,
+    commands: [doctor, capAddIos, capAddAndroid],
+    docs: [
+      'https://capgo.app/docs/getting-started/onboarding/',
+      'https://capgo.app/docs/getting-started/add-an-app/',
+    ],
+    sections: [
+      {
+        title: 'Onboarding state',
+        lines: [
+          `Channel: ${globalChannelName}`,
+          `Platform: ${globalPlatform}`,
+          `Current version: ${globalCurrentVersion ?? 'unknown'}`,
+        ],
+      },
+      ...extraSections,
+    ],
+  })
+}
 
 // Render an init-time file path with its project directory prefix so users
 // can tell which nested project was modified when they run `capgo init` from
@@ -268,6 +317,23 @@ function cancelBeforeAuthenticatedOnboarding(command: boolean | string | symbol)
   }
 }
 
+function getCreateAppTemplateCommand() {
+  const { pm } = getPMAndCommand()
+  if (pm === 'bun') {
+    return {
+      display: 'bun create @capacitor/app@latest',
+      command: 'bun',
+      args: ['create', '@capacitor/app@latest'],
+    }
+  }
+
+  return {
+    display: 'npm init @capacitor/app@latest',
+    command: 'npm',
+    args: ['init', '@capacitor/app@latest'],
+  }
+}
+
 async function waitUntilSetupIsDone(message = 'Type "ready" when the setup is done.') {
   while (true) {
     const ready = await pText({
@@ -376,11 +442,31 @@ async function maybeRunCapacitorInit(projectDir: string, projectType: string, in
   }
 }
 
-function runCreateAppTemplate() {
-  stopInitInkSession({ text: 'Starting Capacitor app template creation...', tone: 'green' })
-  const result = spawnSync('npm', ['init', '@capacitor/app@latest'], { stdio: 'inherit' })
+function runCapacitorPlatformAdd(platformName: 'ios' | 'android', runner: string): boolean {
+  const runnerParts = runner.split(' ').filter(Boolean)
+  const [runnerCommand, ...runnerArgs] = runnerParts
+  const command = formatRunnerCommand(runner, ['cap', 'add', platformName])
+  const spinner = pSpinner()
+  spinner.start(`Running: ${command}`)
+
+  const result = spawnSync(runnerCommand, [...runnerArgs, 'cap', 'add', platformName], { stdio: 'inherit' })
   if (result.error || result.status !== 0) {
-    stdout.write('Capacitor app template creation failed. Run npm init @capacitor/app@latest manually and try again.\n')
+    spinner.stop(`Could not add ${platformName} automatically ❌`)
+    if (result.error)
+      pLog.error(formatError(result.error))
+    return false
+  }
+
+  spinner.stop(`${platformName.toUpperCase()} platform added ✅`)
+  return true
+}
+
+function runCreateAppTemplate() {
+  const templateCommand = getCreateAppTemplateCommand()
+  stopInitInkSession({ text: 'Starting Capacitor app template creation...', tone: 'green' })
+  const result = spawnSync(templateCommand.command, templateCommand.args, { stdio: 'inherit' })
+  if (result.error || result.status !== 0) {
+    stdout.write(`Capacitor app template creation failed. Run ${templateCommand.display} manually and try again.\n`)
     exit(1)
   }
 
@@ -440,8 +526,9 @@ async function ensureWorkspaceReadyForInit(initialAppId?: string): Promise<strin
       return initializedAppId
     }
 
+    const templateCommand = getCreateAppTemplateCommand()
     const createAppNow = await pConfirm({
-      message: 'This folder is not a web app yet. Do you want to start npm init @capacitor/app@latest now?',
+      message: `This folder is not a web app yet. Do you want to start ${templateCommand.display} now?`,
       initialValue: true,
     })
     cancelBeforeAuthenticatedOnboarding(createAppNow)
@@ -449,7 +536,7 @@ async function ensureWorkspaceReadyForInit(initialAppId?: string): Promise<strin
       runCreateAppTemplate()
     }
     else {
-      pLog.info('Create a new Capacitor app first with: npm init @capacitor/app@latest')
+      pLog.info(`Create a new Capacitor app first with: ${templateCommand.display}`)
       pLog.info('Then run this onboarding again from the new app folder.')
       exitBeforeAuthenticatedOnboarding()
     }
@@ -645,22 +732,43 @@ async function selectRecoveryOption<T extends string>(
   message: string,
   options: RecoveryOption<T>[],
 ): Promise<T> {
-  type RecoveryChoice = T | '__cancel__'
-  const choice = await pSelect<RecoveryChoice>({
-    message,
-    options: [
-      ...options,
-      { value: '__cancel__', label: 'Exit onboarding' },
-    ],
-  })
+  type RecoveryChoice = T | '__doctor__' | '__support__' | '__cancel__'
 
-  if (pIsCancel(choice) || choice === '__cancel__') {
-    await markSnag('onboarding-v2', orgId, apikey, 'canceled', undefined, '🤷')
-    pOutro(`Bye 👋\n💡 You can resume the onboarding anytime by running the same command again`)
-    exit(1)
+  while (true) {
+    const choice = await pSelect<RecoveryChoice>({
+      message,
+      options: [
+        ...options,
+        { value: '__doctor__', label: 'Run doctor diagnostics now' },
+        { value: '__support__', label: 'Save a support bundle' },
+        { value: '__cancel__', label: 'Exit onboarding' },
+      ],
+    })
+
+    if (pIsCancel(choice) || choice === '__cancel__') {
+      await markSnag('onboarding-v2', orgId, apikey, 'canceled', undefined, '🤷')
+      pOutro(`Bye 👋\n💡 You can resume the onboarding anytime by running the same command again`)
+      exit(1)
+    }
+
+    if (choice === '__doctor__') {
+      try {
+        await getInfoInternal({ packageJson: globalPathToPackageJson }, false)
+      }
+      catch (error) {
+        pLog.warn(`Doctor found an issue: ${formatError(error)}`)
+      }
+      continue
+    }
+
+    if (choice === '__support__') {
+      const bundlePath = writeInitSupportBundle(message)
+      pLog.info(`Saved support bundle to ${bundlePath}`)
+      continue
+    }
+
+    return choice as T
   }
-
-  return choice as T
 }
 
 async function askForExistingDirectoryPath(orgId: string, apikey: string, message: string, placeholder?: string): Promise<string> {
@@ -738,6 +846,30 @@ async function warnIfNotInCapacitorRoot() {
     pLog.info('Try running the onboarding from the project root (the folder with capacitor.config.*).')
   }
 
+  if (nearest) {
+    const choice = await pSelect({
+      message: 'How do you want to continue?',
+      options: [
+        { value: 'switch', label: `Switch to ${nearest.dir} and continue there` },
+        { value: 'continue', label: 'Stay here and continue anyway' },
+        { value: 'exit', label: 'Exit onboarding' },
+      ],
+    })
+
+    if (pIsCancel(choice) || choice === 'exit') {
+      pCancel('Operation cancelled.')
+      exit(1)
+    }
+
+    if (choice === 'switch') {
+      chdir(nearest.dir)
+      pLog.info(`Switched to ${nearest.dir}`)
+      return
+    }
+
+    return
+  }
+
   const continueAnyway = await pConfirm({
     message: 'Are you sure you want to continue? If you do, the auto-configuration will probably not work from here.',
     initialValue: false,
@@ -790,6 +922,7 @@ async function syncPendingAppIdToCapacitorConfig(appId: string) {
 
 async function handleBrokenIosSync(platformRunner: string, details: string[], orgId: string, apikey: string, failureCount: number) {
   const resetAdvice = getNativeProjectResetAdvice(platformRunner, 'ios')
+  const { doctor } = getInitRecoveryCommands()
   pLog.error('Capgo iOS dependency sync verification failed.')
   for (const detail of details) {
     pLog.error(detail)
@@ -797,6 +930,15 @@ async function handleBrokenIosSync(platformRunner: string, details: string[], or
   pLog.error('The native iOS project is still broken, so this build step cannot continue yet.')
   pLog.warn(resetAdvice.summary)
   pLog.info(resetAdvice.command)
+  pLog.info(`Diagnostics: ${doctor}`)
+
+  if (failureCount >= 2) {
+    const supportBundlePath = writeInitSupportBundle('iOS dependency sync verification failed', [
+      { title: 'Failure details', lines: details },
+      { title: 'Recommended commands', lines: [resetAdvice.command, doctor] },
+    ])
+    pLog.info(`Support bundle: ${supportBundlePath}`)
+  }
 
   if (failureCount % 3 === 0) {
     const cancelInit = await pConfirm({
@@ -2017,7 +2159,7 @@ async function streamCommandInInitPanel(params: {
 
   startInitStreamingOutput({ title: params.title, command: displayCommand })
 
-  const appendChunk = (chunk: { toString(encoding: string): string } | string) => {
+  const appendChunk = (chunk: { toString: (encoding: string) => string } | string) => {
     const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8')
     // Capacitor CLI output mixes \r\n and bare \n; split on both but keep
     // non-empty trimmed lines so the panel doesn't fill with blank rows.
@@ -2774,18 +2916,59 @@ export async function initApp(apikeyCommand: string, appId: string, options: Sup
     const hasIos = existsSync(join(cwd(), iosDir))
     const hasAndroid = existsSync(join(cwd(), androidDir))
     if (!hasIos && !hasAndroid) {
+      const { pm, capAddAndroid, capAddIos } = getInitRecoveryCommands()
       pLog.warn('⚠️  No native platform directories found (ios/ or android/).')
-      pLog.info('   Run "npx cap add ios" or "npx cap add android" to add a platform.')
+      pLog.info(`   Suggested commands: ${capAddIos} or ${capAddAndroid}`)
       const continueWithout = await pSelect({
-        message: 'Continue without native platforms? Later steps may not work.',
+        message: 'How do you want to continue?',
         options: [
-          { value: 'yes', label: '✅ Yes, continue anyway' },
-          { value: 'no', label: '❌ No, I\'ll add a platform first' },
+          { value: 'add-ios', label: `🛠  Run ${capAddIos} now` },
+          { value: 'add-android', label: `🛠  Run ${capAddAndroid} now` },
+          { value: 'yes', label: '✅ Continue without native platforms' },
+          { value: 'no', label: '❌ Exit onboarding' },
         ],
       })
+
       if (pIsCancel(continueWithout) || continueWithout === 'no') {
-        pOutro('Bye 👋\n💡 Run "npx cap add ios" or "npx cap add android", then try again.')
+        pOutro(`Bye 👋\n💡 Run "${capAddIos}" or "${capAddAndroid}", then try again.`)
         exit()
+      }
+
+      if (continueWithout === 'add-ios' || continueWithout === 'add-android') {
+        const platformToAdd = continueWithout === 'add-ios' ? 'ios' : 'android'
+        const added = runCapacitorPlatformAdd(platformToAdd, pm.runner)
+        if (!added) {
+          const recoveryChoice = await pSelect({
+            message: `Could not add ${platformToAdd}. What do you want to do next?`,
+            options: [
+              { value: 'retry', label: `Retry ${platformToAdd} setup` },
+              { value: 'doctor', label: 'Run doctor diagnostics now' },
+              { value: 'continue', label: 'Continue without native platforms' },
+              { value: 'exit', label: 'Exit onboarding' },
+            ],
+          })
+
+          if (pIsCancel(recoveryChoice) || recoveryChoice === 'exit') {
+            pOutro(`Bye 👋\n💡 Run "${platformToAdd === 'ios' ? capAddIos : capAddAndroid}", then try again.`)
+            exit()
+          }
+
+          if (recoveryChoice === 'doctor') {
+            try {
+              await getInfoInternal({ packageJson: globalPathToPackageJson }, false)
+            }
+            catch (error) {
+              pLog.warn(`Doctor found an issue: ${formatError(error)}`)
+            }
+          }
+
+          if (recoveryChoice === 'retry') {
+            const retried = runCapacitorPlatformAdd(platformToAdd, pm.runner)
+            if (!retried) {
+              pLog.warn(`Still could not add ${platformToAdd}. Continuing without native platforms for now.`)
+            }
+          }
+        }
       }
     }
   }
@@ -2910,6 +3093,7 @@ export async function initApp(apikeyCommand: string, appId: string, options: Sup
   let showResumeBanner = stepToSkip > 0
 
   const renderCurrentStep = (stepNumber: number) => {
+    globalCurrentStepNumber = stepNumber
     renderInitOnboardingFrame(stepNumber, totalSteps, { resumed: showResumeBanner })
     showResumeBanner = false
   }
@@ -3023,8 +3207,14 @@ export async function initApp(apikeyCommand: string, appId: string, options: Sup
     cleanupStepsDone()
   }
   catch (e) {
-    pLog.error(`Error during onboarding: ${formatError(e)}`)
-    pLog.error(`Error during onboarding.\n if the error persists please contact support@capgo.app\n Or use manual installation: https://capgo.app/docs/getting-started/add-an-app/`)
+    const formattedError = formatError(e)
+    const supportBundlePath = writeInitSupportBundle(formattedError)
+    const { doctor } = getInitRecoveryCommands()
+
+    pLog.error(`Error during onboarding: ${formattedError}`)
+    pLog.error(`Support bundle saved to ${supportBundlePath}`)
+    pLog.error(`Run ${doctor} for extra diagnostics before contacting support@capgo.app`)
+    pLog.error('Manual installation guide: https://capgo.app/docs/getting-started/add-an-app/')
     exit(1)
   }
 

--- a/src/init/command.ts
+++ b/src/init/command.ts
@@ -1028,7 +1028,7 @@ async function waitForReadyRetry(message: string, orgId: string, apikey: string,
       await cancelCommand(ready, orgId, apikey)
       continue
     }
-    if ((ready as string).trim().toLowerCase() === 'ready')
+    if (typeof ready === 'string' && ready.trim().toLowerCase() === 'ready')
       return
   }
 }

--- a/src/init/command.ts
+++ b/src/init/command.ts
@@ -121,6 +121,21 @@ function writeInitSupportBundle(error: string, extraSections: { title: string, l
   })
 }
 
+async function runInitDoctorDiagnostics(): Promise<void> {
+  try {
+    await getInfoInternal({ packageJson: globalPathToPackageJson }, false)
+  }
+  catch (error) {
+    pLog.warn(`Doctor found an issue: ${formatError(error)}`)
+  }
+}
+
+async function exitCanceledInitOnboarding(orgId: string, apikey: string, message = 'You can resume the onboarding anytime by running the same command again'): Promise<never> {
+  await markSnag('onboarding-v2', orgId, apikey, 'canceled', undefined, '🤷')
+  pOutro(`Bye 👋\n💡 ${message}`)
+  exit(1)
+}
+
 // Render an init-time file path with its project directory prefix so users
 // can tell which nested project was modified when they run `capgo init` from
 // a parent folder (e.g. `CLI/src/main.tsx` instead of `src/main.tsx`).
@@ -459,10 +474,9 @@ function runCapacitorPlatformAdd(platformName: 'ios' | 'android', runner: string
   const spinner = pSpinner()
   spinner.start(`Running: ${command}`)
 
-  let runnerCommand = runner
-  let runnerArgs: string[] = []
+  let parsedRunner: { command: string, args: string[] }
   try {
-    ({ command: runnerCommand, args: runnerArgs } = splitRunnerCommand(runner))
+    parsedRunner = splitRunnerCommand(runner)
   }
   catch (error) {
     spinner.stop(`Could not add ${platformName} automatically ❌`)
@@ -470,7 +484,7 @@ function runCapacitorPlatformAdd(platformName: 'ios' | 'android', runner: string
     return false
   }
 
-  const result = spawnSync(runnerCommand, [...runnerArgs, 'cap', 'add', platformName], { stdio: 'inherit' })
+  const result = spawnSync(parsedRunner.command, [...parsedRunner.args, 'cap', 'add', platformName], { stdio: 'inherit' })
   if (result.error || result.status !== 0) {
     spinner.stop(`Could not add ${platformName} automatically ❌`)
     if (result.error)
@@ -945,69 +959,64 @@ async function syncPendingAppIdToCapacitorConfig(appId: string) {
   }
 }
 
-async function handleBrokenIosSync(platformRunner: string, details: string[], orgId: string, apikey: string, failureCount: number) {
-  const resetAdvice = getNativeProjectResetAdvice(platformRunner, 'ios')
-  const { doctor } = getInitRecoveryCommands()
+function logBrokenIosSync(details: string[], resetAdviceSummary: string, resetAdviceCommand: string, doctorCommand: string): void {
   pLog.error('Capgo iOS dependency sync verification failed.')
   for (const detail of details) {
     pLog.error(detail)
   }
   pLog.error('The native iOS project is still broken, so this build step cannot continue yet.')
-  pLog.warn(resetAdvice.summary)
-  pLog.info(resetAdvice.command)
-  pLog.info(`Diagnostics: ${doctor}`)
+  pLog.warn(resetAdviceSummary)
+  pLog.info(resetAdviceCommand)
+  pLog.info(`Diagnostics: ${doctorCommand}`)
+}
 
-  if (failureCount >= 2) {
-    const supportBundlePath = writeInitSupportBundle('iOS dependency sync verification failed', [
-      { title: 'Failure details', lines: details },
-      { title: 'Recommended commands', lines: [resetAdvice.command, doctor] },
-    ])
-    if (supportBundlePath)
-      pLog.info(`Support bundle: ${supportBundlePath}`)
-    else
-      pLog.warn('Could not save a support bundle automatically.')
-  }
-
-  if (failureCount % 3 === 0) {
-    const cancelInit = await pConfirm({
-      message: `iOS sync has failed ${failureCount} times. Do you want to cancel init?`,
-      initialValue: false,
-    })
-    await cancelCommand(cancelInit, orgId, apikey)
-    if (cancelInit) {
-      await markSnag('onboarding-v2', orgId, apikey, 'canceled', undefined, '🤷')
-      pOutro('Bye 👋\n💡 You can resume the onboarding anytime by running the same command again')
-      exit(1)
-    }
-  }
-
-  const runResetNow = await pConfirm({
-    message: 'Would you like me to run this reset command for you now?',
-    initialValue: true,
-  })
-  await cancelCommand(runResetNow, orgId, apikey)
-
-  if (runResetNow) {
-    const resetSpinner = pSpinner()
-    resetSpinner.start(`Running: ${resetAdvice.command}`)
-    try {
-      execSync(resetAdvice.command, execOption as ExecSyncOptions)
-      resetSpinner.stop('iOS folder recreated and synced ✅')
-    }
-    catch (err) {
-      resetSpinner.stop('iOS folder reset failed ❌')
-      pLog.error(formatError(err))
-    }
+function maybeWriteBrokenIosSyncSupportBundle(failureCount: number, details: string[], resetAdviceCommand: string, doctorCommand: string): void {
+  if (failureCount < 2)
     return
-  }
 
-  pLog.info('We will wait while you fix the iOS folder yourself.')
-  pLog.info('When you are ready, type "ready" and I will retry this step.')
+  const supportBundlePath = writeInitSupportBundle('iOS dependency sync verification failed', [
+    { title: 'Failure details', lines: details },
+    { title: 'Recommended commands', lines: [resetAdviceCommand, doctorCommand] },
+  ])
+  if (supportBundlePath)
+    pLog.info(`Support bundle: ${supportBundlePath}`)
+  else
+    pLog.warn('Could not save a support bundle automatically.')
+}
+
+async function maybeCancelAfterRepeatedIosSyncFailures(failureCount: number, orgId: string, apikey: string): Promise<void> {
+  if (failureCount % 3 !== 0)
+    return
+
+  const cancelInit = await pConfirm({
+    message: `iOS sync has failed ${failureCount} times. Do you want to cancel init?`,
+    initialValue: false,
+  })
+  await cancelCommand(cancelInit, orgId, apikey)
+  if (cancelInit)
+    await exitCanceledInitOnboarding(orgId, apikey)
+}
+
+function runNativeResetCommand(command: string, successMessage: string, failureMessage: string): void {
+  const resetSpinner = pSpinner()
+  resetSpinner.start(`Running: ${command}`)
+  try {
+    execSync(command, execOption as ExecSyncOptions)
+    resetSpinner.stop(successMessage)
+  }
+  catch (err) {
+    resetSpinner.stop(failureMessage)
+    pLog.error(formatError(err))
+  }
+}
+
+async function waitForReadyRetry(message: string, orgId: string, apikey: string, placeholder = 'ready'): Promise<void> {
+  pLog.info(message)
 
   while (true) {
     const ready = await pText({
       message: 'Type "ready" when the iOS folder is fixed.',
-      placeholder: 'ready',
+      placeholder,
       validate: (value) => {
         if (!value?.trim())
           return 'Type "ready" to retry.'
@@ -1017,11 +1026,32 @@ async function handleBrokenIosSync(platformRunner: string, details: string[], or
     })
     if (pIsCancel(ready)) {
       await cancelCommand(ready, orgId, apikey)
+      continue
     }
-    if ((ready as string).trim().toLowerCase() === 'ready') {
+    if ((ready as string).trim().toLowerCase() === 'ready')
       return
-    }
   }
+}
+
+async function handleBrokenIosSync(platformRunner: string, details: string[], orgId: string, apikey: string, failureCount: number) {
+  const resetAdvice = getNativeProjectResetAdvice(platformRunner, 'ios')
+  const { doctor } = getInitRecoveryCommands()
+  logBrokenIosSync(details, resetAdvice.summary, resetAdvice.command, doctor)
+  maybeWriteBrokenIosSyncSupportBundle(failureCount, details, resetAdvice.command, doctor)
+  await maybeCancelAfterRepeatedIosSyncFailures(failureCount, orgId, apikey)
+
+  const runResetNow = await pConfirm({
+    message: 'Would you like me to run this reset command for you now?',
+    initialValue: true,
+  })
+  await cancelCommand(runResetNow, orgId, apikey)
+
+  if (runResetNow) {
+    runNativeResetCommand(resetAdvice.command, 'iOS folder recreated and synced ✅', 'iOS folder reset failed ❌')
+    return
+  }
+
+  await waitForReadyRetry('We will wait while you fix the iOS folder yourself.\nWhen you are ready, type "ready" and I will retry this step.', orgId, apikey)
 }
 
 function validateAppId(value: string | undefined): string | undefined {
@@ -2268,15 +2298,18 @@ function promoteEncryptionSummaryToEnabled(): void {
   setInitEncryptionSummary(promoted)
 }
 
-async function buildProjectStep(orgId: string, apikey: string, appId: string, platform: 'ios' | 'android', config?: CapacitorConfigSnapshot) {
-  const pm = getPMAndCommand()
-  const addPlatformCommand = formatRunnerCommand(pm.runner, ['cap', 'add', platform])
+type PackageManagerInfo = ReturnType<typeof getPMAndCommand>
+type PlatformChoice = 'ios' | 'android'
+type BuildProjectStepOutcome = 'completed' | 'skipped'
+
+async function ensureNativePlatformForBuild(platform: PlatformChoice, config: CapacitorConfigSnapshot | undefined, runner: string): Promise<void> {
+  const addPlatformCommand = formatRunnerCommand(runner, ['cap', 'add', platform])
 
   while (true) {
     const availablePlatforms = getNativePlatformAvailability(config)
     const platformExists = platform === 'ios' ? availablePlatforms.ios : availablePlatforms.android
     if (platformExists)
-      break
+      return
 
     const missingDir = platform === 'ios' ? availablePlatforms.iosDir : availablePlatforms.androidDir
     pLog.warn(`⚠️  ${missingDir}/ is missing, so Capgo cannot build the ${platform.toUpperCase()} project yet.`)
@@ -2296,85 +2329,145 @@ async function buildProjectStep(orgId: string, apikey: string, appId: string, pl
     }
 
     if (recoveryChoice === 'doctor') {
-      try {
-        await getInfoInternal({ packageJson: globalPathToPackageJson }, false)
-      }
-      catch (error) {
-        pLog.warn(`Doctor found an issue: ${formatError(error)}`)
-      }
+      await runInitDoctorDiagnostics()
       continue
     }
 
-    if (!runCapacitorPlatformAdd(platform, pm.runner))
+    if (!runCapacitorPlatformAdd(platform, runner))
       pLog.warn(`Still could not add ${platform}.`)
   }
+}
+
+async function handleMissingBuildScript(buildCommand: string, appId: string, platform: PlatformChoice, orgId: string, apikey: string, pm: PackageManagerInfo): Promise<BuildProjectStepOutcome> {
+  const spinner = pSpinner()
+  spinner.start('Checking project type')
+  spinner.stop('Missing build script', 'neutral')
+  pLog.warn(`❌ Cannot find "${buildCommand}" script in package.json`)
+  pLog.info(`💡 Your package.json needs a "${buildCommand}" script to build the app`)
+
+  const skipBuild = await pConfirm({
+    message: 'Would you like to skip the build for now and continue? You can build manually later.',
+  })
+  await cancelCommand(skipBuild, orgId, apikey)
+
+  if (skipBuild) {
+    pLog.info(`⏭️  Skipping build step - you can build manually with: ${pm.pm} run ${buildCommand}`)
+    pLog.info(`📝 After building, run: ${pm.runner} cap sync ${platform}`)
+    await markStep(orgId, apikey, 'build-project-skipped', appId)
+    return 'skipped'
+  }
+
+  pOutro(`Bye 👋\n💡 Add a "${buildCommand}" script to package.json and run the command again`)
+  exit()
+}
+
+async function runBuildAndSyncLoop(platform: PlatformChoice, buildAndSyncCommand: string, pm: PackageManagerInfo, orgId: string, apikey: string): Promise<void> {
+  let iosSyncFailureCount = 0
+
+  while (true) {
+    const spinner = pSpinner()
+    spinner.start('Checking project type')
+    spinner.message(`Running: ${buildAndSyncCommand}`)
+    execSync(buildAndSyncCommand, execOption as ExecSyncOptions)
+
+    if (platform === 'ios') {
+      const syncValidation = validateIosUpdaterSync(cwd(), globalPathToPackageJson)
+      if (syncValidation.shouldCheck && !syncValidation.valid) {
+        iosSyncFailureCount += 1
+        spinner.stop('iOS sync check failed ❌')
+        await handleBrokenIosSync(pm.runner, syncValidation.details, orgId, apikey, iosSyncFailureCount)
+        pLog.info(`Retrying build and sync for iOS (attempt ${iosSyncFailureCount + 1})`)
+        continue
+      }
+    }
+
+    spinner.stop('Build & Sync Done ✅')
+    promoteEncryptionSummaryToEnabled()
+    return
+  }
+}
+
+async function runProjectBuildAndSync(appId: string, platform: PlatformChoice, orgId: string, apikey: string, pm: PackageManagerInfo): Promise<BuildProjectStepOutcome> {
+  const projectType = await findProjectType()
+  const buildCommand = await findBuildCommandForProjectType(projectType)
+  const packScripts = getPackageScripts()
+
+  if (!packScripts[buildCommand])
+    return handleMissingBuildScript(buildCommand, appId, platform, orgId, apikey, pm)
+
+  const buildAndSyncCommand = `${pm.pm} run ${buildCommand} && ${pm.runner} cap sync ${platform}`
+  await runBuildAndSyncLoop(platform, buildAndSyncCommand, pm, orgId, apikey)
+  return 'completed'
+}
+
+async function buildProjectStep(orgId: string, apikey: string, appId: string, platform: 'ios' | 'android', config?: CapacitorConfigSnapshot) {
+  const pm = getPMAndCommand()
+  await ensureNativePlatformForBuild(platform, config, pm.runner)
 
   const doBuild = await pConfirm({ message: `Automatic build ${appId} with "${pm.pm} run build" ?` })
   await cancelCommand(doBuild, orgId, apikey)
-  if (doBuild) {
-    const projectType = await findProjectType()
-    const buildCommand = await findBuildCommandForProjectType(projectType)
-    const packScripts = getPackageScripts()
-    // check in script build exist
-    if (!packScripts[buildCommand]) {
-      const s = pSpinner()
-      s.start(`Checking project type`)
-      s.stop('Missing build script', 'neutral')
-      pLog.warn(`❌ Cannot find "${buildCommand}" script in package.json`)
-      pLog.info(`💡 Your package.json needs a "${buildCommand}" script to build the app`)
-
-      const skipBuild = await pConfirm({
-        message: `Would you like to skip the build for now and continue? You can build manually later.`,
-      })
-      await cancelCommand(skipBuild, orgId, apikey)
-
-      if (skipBuild) {
-        pLog.info(`⏭️  Skipping build step - you can build manually with: ${pm.pm} run ${buildCommand}`)
-        pLog.info(`📝 After building, run: ${pm.runner} cap sync ${platform}`)
-        await markStep(orgId, apikey, 'build-project-skipped', appId)
-        return
-      }
-
-      pOutro(`Bye 👋\n💡 Add a "${buildCommand}" script to package.json and run the command again`)
-      exit()
-    }
-
-    const buildAndSyncCommand = `${pm.pm} run ${buildCommand} && ${pm.runner} cap sync ${platform}`
-    let iosSyncFailureCount = 0
-
-    while (true) {
-      const s = pSpinner()
-      s.start('Checking project type')
-      s.message(`Running: ${buildAndSyncCommand}`)
-      execSync(buildAndSyncCommand, execOption as ExecSyncOptions)
-
-      if (platform === 'ios') {
-        const syncValidation = validateIosUpdaterSync(cwd(), globalPathToPackageJson)
-        if (syncValidation.shouldCheck && !syncValidation.valid) {
-          iosSyncFailureCount += 1
-          s.stop('iOS sync check failed ❌')
-          await handleBrokenIosSync(pm.runner, syncValidation.details, orgId, apikey, iosSyncFailureCount)
-          pLog.info(`Retrying build and sync for iOS (attempt ${iosSyncFailureCount + 1})`)
-          continue
-        }
-      }
-
-      s.stop('Build & Sync Done ✅')
-      // Now that `cap sync` has actually copied the new public key into
-      // the native project, we can truthfully claim encryption is fully
-      // enabled. Before this point the summary was "pending-sync".
-      promoteEncryptionSummaryToEnabled()
-      break
-    }
-  }
-  else {
+  if (!doBuild) {
     pLog.info(`Build yourself with command: ${pm.pm} run build && ${pm.runner} cap sync ${platform}`)
-    // User declined the automatic build — we can't verify cap sync ran,
-    // so leave the encryption summary at `pending-sync` with its
-    // "encrypted updates will fail until the native project is synced"
-    // warning intact.
+    await markStep(orgId, apikey, 'build-project', appId)
+    return
   }
+
+  const buildOutcome = await runProjectBuildAndSync(appId, platform, orgId, apikey, pm)
+  if (buildOutcome === 'skipped')
+    return
+
   await markStep(orgId, apikey, 'build-project', appId)
+}
+
+function getSelectablePlatformOptions(config?: CapacitorConfigSnapshot): Array<{ value: PlatformChoice, label: string }> {
+  const availablePlatforms = getNativePlatformAvailability(config)
+  const options: Array<{ value: PlatformChoice, label: string }> = []
+  if (availablePlatforms.ios)
+    options.push({ value: 'ios', label: 'IOS' })
+  if (availablePlatforms.android)
+    options.push({ value: 'android', label: 'Android' })
+  return options
+}
+
+async function promptForSelectedPlatform(orgId: string, apikey: string, options: Array<{ value: PlatformChoice, label: string }>): Promise<PlatformChoice> {
+  const platformType = await pSelect({
+    message: 'Which platform do you want to test with during this onboarding?',
+    options,
+  })
+  if (pIsCancel(platformType))
+    await exitCanceledInitOnboarding(orgId, apikey)
+
+  const platform = platformType as PlatformChoice
+  pLog.info(`🎯 Testing with: ${platform.toUpperCase()}`)
+  pLog.info(`💡 Note: Onboarding builds will use ${platform} only`)
+  await markStep(orgId, apikey, 'select-platform', platform)
+  return platform
+}
+
+async function handleMissingPlatformSelection(orgId: string, apikey: string, availablePlatforms: ReturnType<typeof getNativePlatformAvailability>): Promise<void> {
+  const { pm, capAddAndroid, capAddIos } = getInitRecoveryCommands()
+  pLog.warn(`⚠️  No native platform directories found (${availablePlatforms.iosDir}/ or ${availablePlatforms.androidDir}/).`)
+  const recoveryChoice = await pSelect({
+    message: 'Add a native platform before choosing a test platform.',
+    options: [
+      { value: 'add-ios', label: `🛠  Run ${capAddIos} now` },
+      { value: 'add-android', label: `🛠  Run ${capAddAndroid} now` },
+      { value: 'doctor', label: 'Run doctor diagnostics now' },
+      { value: 'exit', label: 'Exit onboarding' },
+    ],
+  })
+
+  if (pIsCancel(recoveryChoice) || recoveryChoice === 'exit')
+    await exitCanceledInitOnboarding(orgId, apikey, `Run "${capAddIos}" or "${capAddAndroid}", then try again.`)
+
+  if (recoveryChoice === 'doctor') {
+    await runInitDoctorDiagnostics()
+    return
+  }
+
+  const platformToAdd = recoveryChoice === 'add-ios' ? 'ios' : 'android'
+  if (!runCapacitorPlatformAdd(platformToAdd, pm.runner))
+    pLog.warn(`Still could not add ${platformToAdd}.`)
 }
 
 async function selectPlatformStep(orgId: string, apikey: string, config?: CapacitorConfigSnapshot): Promise<'ios' | 'android'> {
@@ -2382,62 +2475,11 @@ async function selectPlatformStep(orgId: string, apikey: string, config?: Capaci
   pLog.info(`   This is just for testing during onboarding - your app will work on all platforms`)
 
   while (true) {
-    const availablePlatforms = getNativePlatformAvailability(config)
-    const options: Array<{ value: 'ios' | 'android', label: string }> = []
-    if (availablePlatforms.ios)
-      options.push({ value: 'ios', label: 'IOS' })
-    if (availablePlatforms.android)
-      options.push({ value: 'android', label: 'Android' })
+    const options = getSelectablePlatformOptions(config)
+    if (options.length > 0)
+      return promptForSelectedPlatform(orgId, apikey, options)
 
-    if (options.length > 0) {
-      const platformType = await pSelect({
-        message: 'Which platform do you want to test with during this onboarding?',
-        options,
-      })
-      if (pIsCancel(platformType)) {
-        await markSnag('onboarding-v2', orgId, apikey, 'canceled', undefined, '🤷')
-        pOutro(`Bye 👋\n💡 You can resume the onboarding anytime by running the same command again`)
-        exit()
-      }
-
-      const platform = platformType as 'ios' | 'android'
-      pLog.info(`🎯 Testing with: ${platform.toUpperCase()}`)
-      pLog.info(`💡 Note: Onboarding builds will use ${platform} only`)
-      await markStep(orgId, apikey, 'select-platform', platform)
-      return platform
-    }
-
-    const { pm, capAddAndroid, capAddIos } = getInitRecoveryCommands()
-    pLog.warn(`⚠️  No native platform directories found (${availablePlatforms.iosDir}/ or ${availablePlatforms.androidDir}/).`)
-    const recoveryChoice = await pSelect({
-      message: 'Add a native platform before choosing a test platform.',
-      options: [
-        { value: 'add-ios', label: `🛠  Run ${capAddIos} now` },
-        { value: 'add-android', label: `🛠  Run ${capAddAndroid} now` },
-        { value: 'doctor', label: 'Run doctor diagnostics now' },
-        { value: 'exit', label: 'Exit onboarding' },
-      ],
-    })
-
-    if (pIsCancel(recoveryChoice) || recoveryChoice === 'exit') {
-      await markSnag('onboarding-v2', orgId, apikey, 'canceled', undefined, '🤷')
-      pOutro(`Bye 👋\n💡 Run "${capAddIos}" or "${capAddAndroid}", then try again.`)
-      exit()
-    }
-
-    if (recoveryChoice === 'doctor') {
-      try {
-        await getInfoInternal({ packageJson: globalPathToPackageJson }, false)
-      }
-      catch (error) {
-        pLog.warn(`Doctor found an issue: ${formatError(error)}`)
-      }
-      continue
-    }
-
-    const platformToAdd = recoveryChoice === 'add-ios' ? 'ios' : 'android'
-    if (!runCapacitorPlatformAdd(platformToAdd, pm.runner))
-      pLog.warn(`Still could not add ${platformToAdd}.`)
+    await handleMissingPlatformSelection(orgId, apikey, getNativePlatformAvailability(config))
   }
 }
 

--- a/src/init/command.ts
+++ b/src/init/command.ts
@@ -997,11 +997,22 @@ async function maybeCancelAfterRepeatedIosSyncFailures(failureCount: number, org
     await exitCanceledInitOnboarding(orgId, apikey)
 }
 
-function runNativeResetCommand(command: string, successMessage: string, failureMessage: string): void {
+function runNativeResetCommand(platformRunner: string, nativePlatform: PlatformChoice, successMessage: string, failureMessage: string): void {
+  const resetAdvice = getNativeProjectResetAdvice(platformRunner, nativePlatform)
   const resetSpinner = pSpinner()
-  resetSpinner.start(`Running: ${command}`)
+  resetSpinner.start(`Running: ${resetAdvice.command}`)
   try {
-    execSync(command, execOption as ExecSyncOptions)
+    const parsedRunner = splitRunnerCommand(platformRunner)
+    rmSync(nativePlatform, { recursive: true, force: true })
+
+    const addResult = spawnSync(parsedRunner.command, [...parsedRunner.args, 'cap', 'add', nativePlatform], { stdio: 'inherit' })
+    if (addResult.error || addResult.status !== 0)
+      throw addResult.error ?? new Error(`cap add ${nativePlatform} failed with code ${addResult.status ?? 'unknown'}`)
+
+    const syncResult = spawnSync(parsedRunner.command, [...parsedRunner.args, 'cap', 'sync', nativePlatform], { stdio: 'inherit' })
+    if (syncResult.error || syncResult.status !== 0)
+      throw syncResult.error ?? new Error(`cap sync ${nativePlatform} failed with code ${syncResult.status ?? 'unknown'}`)
+
     resetSpinner.stop(successMessage)
   }
   catch (err) {
@@ -1047,7 +1058,7 @@ async function handleBrokenIosSync(platformRunner: string, details: string[], or
   await cancelCommand(runResetNow, orgId, apikey)
 
   if (runResetNow) {
-    runNativeResetCommand(resetAdvice.command, 'iOS folder recreated and synced ✅', 'iOS folder reset failed ❌')
+    runNativeResetCommand(platformRunner, 'ios', 'iOS folder recreated and synced ✅', 'iOS folder reset failed ❌')
     return
   }
 

--- a/src/init/command.ts
+++ b/src/init/command.ts
@@ -50,6 +50,7 @@ const frameworkSetupGuides = {
   nuxtjs: 'https://capgo.app/blog/nuxt-mobile-app-capacitor-from-scratch/',
   sveltekit: 'https://capgo.app/blog/creating-mobile-apps-with-sveltekit-and-capacitor/',
 } as const
+type CapacitorConfigSnapshot = Awaited<ReturnType<typeof getConfig>>['config']
 
 let tmpObject: tmp.FileResult['name'] | undefined
 let globalPathToPackageJson: string | undefined
@@ -63,6 +64,17 @@ let globalEncryptionSummary: InitEncryptionSummary | undefined
 let globalCurrentStepNumber = 0
 
 const CODE_DIFF_CONTEXT_LINES = 5
+
+function getNativePlatformAvailability(config?: CapacitorConfigSnapshot) {
+  const iosDir = getPlatformDirFromCapacitorConfig(config, 'ios')
+  const androidDir = getPlatformDirFromCapacitorConfig(config, 'android')
+  return {
+    iosDir,
+    androidDir,
+    ios: existsSync(join(cwd(), iosDir)),
+    android: existsSync(join(cwd(), androidDir)),
+  }
+}
 
 function getInitRecoveryCommands() {
   const pm = getPMAndCommand()
@@ -730,6 +742,7 @@ async function selectRecoveryOption<T extends string>(
   apikey: string,
   message: string,
   options: RecoveryOption<T>[],
+  failureText = message,
 ): Promise<T> {
   type RecoveryChoice = T | '__doctor__' | '__support__' | '__cancel__'
 
@@ -761,8 +774,11 @@ async function selectRecoveryOption<T extends string>(
     }
 
     if (choice === '__support__') {
-      const bundlePath = writeInitSupportBundle(message)
-      pLog.info(`Saved support bundle to ${bundlePath}`)
+      const bundlePath = writeInitSupportBundle(failureText)
+      if (bundlePath)
+        pLog.info(`Saved support bundle to ${bundlePath}`)
+      else
+        pLog.warn('Could not save a support bundle automatically.')
       continue
     }
 
@@ -936,7 +952,10 @@ async function handleBrokenIosSync(platformRunner: string, details: string[], or
       { title: 'Failure details', lines: details },
       { title: 'Recommended commands', lines: [resetAdvice.command, doctor] },
     ])
-    pLog.info(`Support bundle: ${supportBundlePath}`)
+    if (supportBundlePath)
+      pLog.info(`Support bundle: ${supportBundlePath}`)
+    else
+      pLog.warn('Could not save a support bundle automatically.')
   }
 
   if (failureCount % 3 === 0) {
@@ -1661,7 +1680,7 @@ async function addUpdaterStep(orgId: string, apikey: string, appId: string) {
         pLog.warn(blocker)
         await selectRecoveryOption(orgId, apikey, 'Fix the project, then choose what to do next.', [
           { value: 'retry', label: 'Retry updater checks' },
-        ])
+        ], blocker)
         continue
       }
 
@@ -1723,7 +1742,7 @@ async function addUpdaterStep(orgId: string, apikey: string, appId: string) {
         pLog.error(formatError(error))
         await selectRecoveryOption(orgId, apikey, 'Updater install failed. What do you want to do?', [
           { value: 'retry', label: 'Retry updater install' },
-        ])
+        ], formatError(error))
       }
     }
   }
@@ -2100,11 +2119,12 @@ async function addEncryptionStep(orgId: string, apikey: string, appId: string) {
     }
     catch (error) {
       s.stop('Error', 'error')
-      pLog.warn(`Cannot create key ❌ ${error instanceof Error ? error.message : String(error)}`)
+      const failureText = error instanceof Error ? error.message : String(error)
+      pLog.warn(`Cannot create key ❌ ${failureText}`)
       const recoveryChoice = await selectRecoveryOption(orgId, apikey, 'Encryption key creation failed. What do you want to do?', [
         { value: 'retry', label: 'Retry key creation' },
         { value: 'skip', label: 'Continue without encryption' },
-      ])
+      ], failureText)
 
       if (recoveryChoice === 'retry') {
         return addEncryptionStep(orgId, apikey, appId)
@@ -2238,8 +2258,47 @@ function promoteEncryptionSummaryToEnabled(): void {
   setInitEncryptionSummary(promoted)
 }
 
-async function buildProjectStep(orgId: string, apikey: string, appId: string, platform: 'ios' | 'android') {
+async function buildProjectStep(orgId: string, apikey: string, appId: string, platform: 'ios' | 'android', config?: CapacitorConfigSnapshot) {
   const pm = getPMAndCommand()
+  const addPlatformCommand = formatRunnerCommand(pm.runner, ['cap', 'add', platform])
+
+  while (true) {
+    const availablePlatforms = getNativePlatformAvailability(config)
+    const platformExists = platform === 'ios' ? availablePlatforms.ios : availablePlatforms.android
+    if (platformExists)
+      break
+
+    const missingDir = platform === 'ios' ? availablePlatforms.iosDir : availablePlatforms.androidDir
+    pLog.warn(`⚠️  ${missingDir}/ is missing, so Capgo cannot build the ${platform.toUpperCase()} project yet.`)
+
+    const recoveryChoice = await pSelect({
+      message: `How do you want to continue with ${platform.toUpperCase()}?`,
+      options: [
+        { value: 'add', label: `🛠  Run ${addPlatformCommand} now` },
+        { value: 'doctor', label: 'Run doctor diagnostics now' },
+        { value: 'exit', label: 'Exit onboarding' },
+      ],
+    })
+
+    if (pIsCancel(recoveryChoice) || recoveryChoice === 'exit') {
+      pOutro(`Bye 👋\n💡 Run "${addPlatformCommand}", then try again.`)
+      exit()
+    }
+
+    if (recoveryChoice === 'doctor') {
+      try {
+        await getInfoInternal({ packageJson: globalPathToPackageJson }, false)
+      }
+      catch (error) {
+        pLog.warn(`Doctor found an issue: ${formatError(error)}`)
+      }
+      continue
+    }
+
+    if (!runCapacitorPlatformAdd(platform, pm.runner))
+      pLog.warn(`Still could not add ${platform}.`)
+  }
+
   const doBuild = await pConfirm({ message: `Automatic build ${appId} with "${pm.pm} run build" ?` })
   await cancelCommand(doBuild, orgId, apikey)
   if (doBuild) {
@@ -2308,28 +2367,68 @@ async function buildProjectStep(orgId: string, apikey: string, appId: string, pl
   await markStep(orgId, apikey, 'build-project', appId)
 }
 
-async function selectPlatformStep(orgId: string, apikey: string): Promise<'ios' | 'android'> {
+async function selectPlatformStep(orgId: string, apikey: string, config?: CapacitorConfigSnapshot): Promise<'ios' | 'android'> {
   pLog.info(`📱 Platform selection for onboarding`)
   pLog.info(`   This is just for testing during onboarding - your app will work on all platforms`)
 
-  const platformType = await pSelect({
-    message: 'Which platform do you want to test with during this onboarding?',
-    options: [
-      { value: 'ios', label: 'IOS' },
-      { value: 'android', label: 'Android' },
-    ],
-  })
-  if (pIsCancel(platformType)) {
-    await markSnag('onboarding-v2', orgId, apikey, 'canceled', undefined, '🤷')
-    pOutro(`Bye 👋\n💡 You can resume the onboarding anytime by running the same command again`)
-    exit()
-  }
+  while (true) {
+    const availablePlatforms = getNativePlatformAvailability(config)
+    const options: Array<{ value: 'ios' | 'android', label: string }> = []
+    if (availablePlatforms.ios)
+      options.push({ value: 'ios', label: 'IOS' })
+    if (availablePlatforms.android)
+      options.push({ value: 'android', label: 'Android' })
 
-  const platform = platformType as 'ios' | 'android'
-  pLog.info(`🎯 Testing with: ${platform.toUpperCase()}`)
-  pLog.info(`💡 Note: Onboarding builds will use ${platform} only`)
-  await markStep(orgId, apikey, 'select-platform', platform)
-  return platform
+    if (options.length > 0) {
+      const platformType = await pSelect({
+        message: 'Which platform do you want to test with during this onboarding?',
+        options,
+      })
+      if (pIsCancel(platformType)) {
+        await markSnag('onboarding-v2', orgId, apikey, 'canceled', undefined, '🤷')
+        pOutro(`Bye 👋\n💡 You can resume the onboarding anytime by running the same command again`)
+        exit()
+      }
+
+      const platform = platformType as 'ios' | 'android'
+      pLog.info(`🎯 Testing with: ${platform.toUpperCase()}`)
+      pLog.info(`💡 Note: Onboarding builds will use ${platform} only`)
+      await markStep(orgId, apikey, 'select-platform', platform)
+      return platform
+    }
+
+    const { pm, capAddAndroid, capAddIos } = getInitRecoveryCommands()
+    pLog.warn(`⚠️  No native platform directories found (${availablePlatforms.iosDir}/ or ${availablePlatforms.androidDir}/).`)
+    const recoveryChoice = await pSelect({
+      message: 'Add a native platform before choosing a test platform.',
+      options: [
+        { value: 'add-ios', label: `🛠  Run ${capAddIos} now` },
+        { value: 'add-android', label: `🛠  Run ${capAddAndroid} now` },
+        { value: 'doctor', label: 'Run doctor diagnostics now' },
+        { value: 'exit', label: 'Exit onboarding' },
+      ],
+    })
+
+    if (pIsCancel(recoveryChoice) || recoveryChoice === 'exit') {
+      await markSnag('onboarding-v2', orgId, apikey, 'canceled', undefined, '🤷')
+      pOutro(`Bye 👋\n💡 Run "${capAddIos}" or "${capAddAndroid}", then try again.`)
+      exit()
+    }
+
+    if (recoveryChoice === 'doctor') {
+      try {
+        await getInfoInternal({ packageJson: globalPathToPackageJson }, false)
+      }
+      catch (error) {
+        pLog.warn(`Doctor found an issue: ${formatError(error)}`)
+      }
+      continue
+    }
+
+    const platformToAdd = recoveryChoice === 'add-ios' ? 'ios' : 'android'
+    if (!runCapacitorPlatformAdd(platformToAdd, pm.runner))
+      pLog.warn(`Still could not add ${platformToAdd}.`)
+  }
 }
 
 async function runDeviceStep(orgId: string, apikey: string, appId: string, platform: 'ios' | 'android') {
@@ -2656,14 +2755,14 @@ async function uploadStep(orgId: string, apikey: string, appId: string, newVersi
         pLog.error(formatError(error))
         await selectRecoveryOption(orgId, apikey, 'Bundle upload failed. What do you want to do?', [
           { value: 'retry', label: 'Retry bundle upload' },
-        ])
+        ], formatError(error))
         continue
       }
       if (!uploadRes?.success) {
         s.stop('Upload failed ❌')
         await selectRecoveryOption(orgId, apikey, 'Bundle upload failed. What do you want to do?', [
           { value: 'retry', label: 'Retry bundle upload' },
-        ])
+        ], 'Bundle upload did not complete successfully.')
         continue
       }
 
@@ -2914,13 +3013,10 @@ export async function initApp(apikeyCommand: string, appId: string, options: Sup
     }
   }
   else {
-    const iosDir = getPlatformDirFromCapacitorConfig(extConfig?.config, 'ios')
-    const androidDir = getPlatformDirFromCapacitorConfig(extConfig?.config, 'android')
-    const hasIos = existsSync(join(cwd(), iosDir))
-    const hasAndroid = existsSync(join(cwd(), androidDir))
-    if (!hasIos && !hasAndroid) {
+    const availablePlatforms = getNativePlatformAvailability(extConfig?.config)
+    if (!availablePlatforms.ios && !availablePlatforms.android) {
       const { pm, capAddAndroid, capAddIos } = getInitRecoveryCommands()
-      pLog.warn('⚠️  No native platform directories found (ios/ or android/).')
+      pLog.warn(`⚠️  No native platform directories found (${availablePlatforms.iosDir}/ or ${availablePlatforms.androidDir}/).`)
       pLog.info(`   Suggested commands: ${capAddIos} or ${capAddAndroid}`)
       const continueWithout = await pSelect({
         message: 'How do you want to continue?',
@@ -3149,7 +3245,7 @@ export async function initApp(apikeyCommand: string, appId: string, options: Sup
 
     if (stepToSkip < 6) {
       renderCurrentStep(6)
-      platform = await selectPlatformStep(orgId, options.apikey)
+      platform = await selectPlatformStep(orgId, options.apikey, extConfig?.config)
       globalPlatform = platform
       markStepDone(6)
     }
@@ -3163,7 +3259,7 @@ export async function initApp(apikeyCommand: string, appId: string, options: Sup
       // Keeping it mounted through step 7 means the user sees the status
       // change the moment sync completes, which is much clearer than a
       // panel that silently disappears.
-      await buildProjectStep(orgId, options.apikey, appId, platform)
+      await buildProjectStep(orgId, options.apikey, appId, platform, extConfig?.config)
       markStepDone(7)
     }
 
@@ -3215,7 +3311,10 @@ export async function initApp(apikeyCommand: string, appId: string, options: Sup
     const { doctor } = getInitRecoveryCommands()
 
     pLog.error(`Error during onboarding: ${formattedError}`)
-    pLog.error(`Support bundle saved to ${supportBundlePath}`)
+    if (supportBundlePath)
+      pLog.error(`Support bundle saved to ${supportBundlePath}`)
+    else
+      pLog.error('Could not save a support bundle automatically.')
     pLog.error(`Run ${doctor} for extra diagnostics before contacting support@capgo.app`)
     pLog.error('Manual installation guide: https://capgo.app/docs/getting-started/add-an-app/')
     exit(1)

--- a/src/init/command.ts
+++ b/src/init/command.ts
@@ -24,7 +24,7 @@ import { createKeyInternal } from '../key'
 import { doLoginExists, loginInternal } from '../login'
 import { writeOnboardingSupportBundle } from '../onboarding-support'
 import { showReplicationProgress } from '../replicationProgress'
-import { formatRunnerCommand } from '../runner-command'
+import { formatRunnerCommand, splitRunnerCommand } from '../runner-command'
 import { createSupabaseClient, findBuildCommandForProjectType, findMainFile, findMainFileForProjectType, findProjectType, findRoot, findSavedKey, formatError, getAllPackagesDependencies, getAppId, getBundleVersion, getConfig, getInstalledVersion, getLocalConfig, getNativeProjectResetAdvice, getPackageScripts, getPMAndCommand, PACKNAME, projectIsMonorepo, updateConfigbyKey, updateConfigUpdater, validateIosUpdaterSync, verifyUser } from '../utils'
 import { cancel as pCancel, confirm as pConfirm, intro as pIntro, isCancel as pIsCancel, log as pLog, outro as pOutro, select as pSelect, spinner as pSpinner, text as pText } from './prompts'
 import { appendInitStreamingLine, clearInitStreamingOutput, setInitCodeDiff, setInitEncryptionSummary, setInitVersionWarning, startInitStreamingOutput, stopInitInkSession, updateInitStreamingStatus } from './runtime'
@@ -443,8 +443,7 @@ async function maybeRunCapacitorInit(projectDir: string, projectType: string, in
 }
 
 function runCapacitorPlatformAdd(platformName: 'ios' | 'android', runner: string): boolean {
-  const runnerParts = runner.split(' ').filter(Boolean)
-  const [runnerCommand, ...runnerArgs] = runnerParts
+  const { command: runnerCommand, args: runnerArgs } = splitRunnerCommand(runner)
   const command = formatRunnerCommand(runner, ['cap', 'add', platformName])
   const spinner = pSpinner()
   spinner.start(`Running: ${command}`)
@@ -2150,10 +2149,14 @@ async function streamCommandInInitPanel(params: {
   // `pm.runner` can contain a space ("yarn dlx", "pnpm exec"). `spawn`
   // without `shell:true` can't handle that, and `shell:true` brings
   // quoting risk, so we split the runner into its own head + tail args.
-  const runnerParts = params.runner.split(' ').filter(Boolean)
-  if (runnerParts.length === 0)
-    return { success: false, error: new Error(`Invalid package manager runner: "${params.runner}"`) }
-  const [runnerCmd, ...runnerArgs] = runnerParts
+  let runnerCommand
+  try {
+    runnerCommand = splitRunnerCommand(params.runner)
+  }
+  catch (error) {
+    return { success: false, error: error instanceof Error ? error : new Error(String(error)) }
+  }
+  const { command: runnerCmd, args: runnerArgs } = runnerCommand
   const fullArgs = [...runnerArgs, ...params.args]
   const displayCommand = `${params.runner} ${params.args.join(' ')}`
 

--- a/src/init/command.ts
+++ b/src/init/command.ts
@@ -455,10 +455,20 @@ async function maybeRunCapacitorInit(projectDir: string, projectType: string, in
 }
 
 function runCapacitorPlatformAdd(platformName: 'ios' | 'android', runner: string): boolean {
-  const { command: runnerCommand, args: runnerArgs } = splitRunnerCommand(runner)
   const command = formatRunnerCommand(runner, ['cap', 'add', platformName])
   const spinner = pSpinner()
   spinner.start(`Running: ${command}`)
+
+  let runnerCommand = runner
+  let runnerArgs: string[] = []
+  try {
+    ({ command: runnerCommand, args: runnerArgs } = splitRunnerCommand(runner))
+  }
+  catch (error) {
+    spinner.stop(`Could not add ${platformName} automatically ❌`)
+    pLog.error(formatError(error))
+    return false
+  }
 
   const result = spawnSync(runnerCommand, [...runnerArgs, 'cap', 'add', platformName], { stdio: 'inherit' })
   if (result.error || result.status !== 0) {

--- a/src/onboarding-support.ts
+++ b/src/onboarding-support.ts
@@ -1,0 +1,94 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+export interface OnboardingSupportSection {
+  title: string
+  lines: string[]
+}
+
+export interface OnboardingSupportBundleInput {
+  kind: 'init' | 'build-init'
+  error: string
+  appId?: string
+  currentStep?: string
+  packageManager?: string
+  cwd?: string
+  commands?: string[]
+  docs?: string[]
+  logs?: string[]
+  sections?: OnboardingSupportSection[]
+}
+
+function sanitizeSegment(value: string | undefined, fallback: string): string {
+  const trimmed = value?.trim()
+  if (!trimmed)
+    return fallback
+  return trimmed.replaceAll(/[^\w.-]+/g, '-').replaceAll(/-+/g, '-').replaceAll(/^-|-$/g, '') || fallback
+}
+
+function nowStamp(): string {
+  return new Date().toISOString().replaceAll(/[:.]/g, '-')
+}
+
+export function renderOnboardingSupportBundle(input: OnboardingSupportBundleInput): string {
+  const lines: string[] = [
+    `Capgo ${input.kind} support bundle`,
+    `Generated: ${new Date().toISOString()}`,
+    `Error: ${input.error}`,
+  ]
+
+  if (input.appId)
+    lines.push(`App ID: ${input.appId}`)
+  if (input.currentStep)
+    lines.push(`Current step: ${input.currentStep}`)
+  if (input.packageManager)
+    lines.push(`Package manager: ${input.packageManager}`)
+  if (input.cwd)
+    lines.push(`Working directory: ${input.cwd}`)
+
+  if (input.commands?.length) {
+    lines.push('', 'Recommended commands:')
+    for (const command of input.commands) {
+      lines.push(`- ${command}`)
+    }
+  }
+
+  if (input.docs?.length) {
+    lines.push('', 'Docs:')
+    for (const doc of input.docs) {
+      lines.push(`- ${doc}`)
+    }
+  }
+
+  if (input.sections?.length) {
+    for (const section of input.sections) {
+      lines.push('', `${section.title}:`)
+      for (const line of section.lines) {
+        lines.push(line)
+      }
+    }
+  }
+
+  if (input.logs?.length) {
+    lines.push('', 'Recent logs:')
+    for (const line of input.logs) {
+      lines.push(line)
+    }
+  }
+
+  return `${lines.join('\n')}\n`
+}
+
+export function writeOnboardingSupportBundle(input: OnboardingSupportBundleInput): string {
+  const supportDir = join(homedir(), '.capgo-credentials', 'support')
+  mkdirSync(supportDir, { recursive: true })
+
+  const kind = sanitizeSegment(input.kind, 'onboarding')
+  const app = sanitizeSegment(input.appId, 'unknown-app')
+  const filename = `${kind}-${app}-${nowStamp()}.log`
+  const filePath = join(supportDir, filename)
+
+  writeFileSync(filePath, renderOnboardingSupportBundle(input), 'utf8')
+  return filePath
+}

--- a/src/onboarding-support.ts
+++ b/src/onboarding-support.ts
@@ -2,6 +2,11 @@ import { mkdirSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 
+const NON_SEGMENT_RE = /[^\w.-]+/g
+const DASHES_RE = /-+/g
+const EDGE_DASH_RE = /^-|-$/g
+const TIMESTAMP_RE = /[:.]/g
+
 export interface OnboardingSupportSection {
   title: string
   lines: string[]
@@ -24,11 +29,11 @@ function sanitizeSegment(value: string | undefined, fallback: string): string {
   const trimmed = value?.trim()
   if (!trimmed)
     return fallback
-  return trimmed.replaceAll(/[^\w.-]+/g, '-').replaceAll(/-+/g, '-').replaceAll(/^-|-$/g, '') || fallback
+  return trimmed.replaceAll(NON_SEGMENT_RE, '-').replaceAll(DASHES_RE, '-').replaceAll(EDGE_DASH_RE, '') || fallback
 }
 
 function nowStamp(): string {
-  return new Date().toISOString().replaceAll(/[:.]/g, '-')
+  return new Date().toISOString().replaceAll(TIMESTAMP_RE, '-')
 }
 
 export function renderOnboardingSupportBundle(input: OnboardingSupportBundleInput): string {
@@ -80,15 +85,19 @@ export function renderOnboardingSupportBundle(input: OnboardingSupportBundleInpu
   return `${lines.join('\n')}\n`
 }
 
-export function writeOnboardingSupportBundle(input: OnboardingSupportBundleInput): string {
-  const supportDir = join(homedir(), '.capgo-credentials', 'support')
-  mkdirSync(supportDir, { recursive: true })
+export function writeOnboardingSupportBundle(input: OnboardingSupportBundleInput, supportDir = join(homedir(), '.capgo-credentials', 'support')): string | null {
+  try {
+    mkdirSync(supportDir, { recursive: true })
 
-  const kind = sanitizeSegment(input.kind, 'onboarding')
-  const app = sanitizeSegment(input.appId, 'unknown-app')
-  const filename = `${kind}-${app}-${nowStamp()}.log`
-  const filePath = join(supportDir, filename)
+    const kind = sanitizeSegment(input.kind, 'onboarding')
+    const app = sanitizeSegment(input.appId, 'unknown-app')
+    const filename = `${kind}-${app}-${nowStamp()}.log`
+    const filePath = join(supportDir, filename)
 
-  writeFileSync(filePath, renderOnboardingSupportBundle(input), 'utf8')
-  return filePath
+    writeFileSync(filePath, renderOnboardingSupportBundle(input), 'utf8')
+    return filePath
+  }
+  catch {
+    return null
+  }
 }

--- a/src/onboarding-support.ts
+++ b/src/onboarding-support.ts
@@ -36,6 +36,23 @@ function nowStamp(): string {
   return new Date().toISOString().replaceAll(TIMESTAMP_RE, '-')
 }
 
+function appendMetadataLine(lines: string[], label: string, value: string | undefined): void {
+  if (value)
+    lines.push(`${label}: ${value}`)
+}
+
+function appendBulletedSection(lines: string[], title: string, items: string[] | undefined): void {
+  if (!items?.length)
+    return
+  lines.push('', `${title}:`, ...items.map(item => `- ${item}`))
+}
+
+function appendPlainSection(lines: string[], title: string, items: string[] | undefined): void {
+  if (!items?.length)
+    return
+  lines.push('', `${title}:`, ...items)
+}
+
 export function renderOnboardingSupportBundle(input: OnboardingSupportBundleInput): string {
   const lines: string[] = [
     `Capgo ${input.kind} support bundle`,
@@ -43,44 +60,18 @@ export function renderOnboardingSupportBundle(input: OnboardingSupportBundleInpu
     `Error: ${input.error}`,
   ]
 
-  if (input.appId)
-    lines.push(`App ID: ${input.appId}`)
-  if (input.currentStep)
-    lines.push(`Current step: ${input.currentStep}`)
-  if (input.packageManager)
-    lines.push(`Package manager: ${input.packageManager}`)
-  if (input.cwd)
-    lines.push(`Working directory: ${input.cwd}`)
+  appendMetadataLine(lines, 'App ID', input.appId)
+  appendMetadataLine(lines, 'Current step', input.currentStep)
+  appendMetadataLine(lines, 'Package manager', input.packageManager)
+  appendMetadataLine(lines, 'Working directory', input.cwd)
+  appendBulletedSection(lines, 'Recommended commands', input.commands)
+  appendBulletedSection(lines, 'Docs', input.docs)
 
-  if (input.commands?.length) {
-    lines.push('', 'Recommended commands:')
-    for (const command of input.commands) {
-      lines.push(`- ${command}`)
-    }
+  for (const section of input.sections ?? []) {
+    appendPlainSection(lines, section.title, section.lines)
   }
 
-  if (input.docs?.length) {
-    lines.push('', 'Docs:')
-    for (const doc of input.docs) {
-      lines.push(`- ${doc}`)
-    }
-  }
-
-  if (input.sections?.length) {
-    for (const section of input.sections) {
-      lines.push('', `${section.title}:`)
-      for (const line of section.lines) {
-        lines.push(line)
-      }
-    }
-  }
-
-  if (input.logs?.length) {
-    lines.push('', 'Recent logs:')
-    for (const line of input.logs) {
-      lines.push(line)
-    }
-  }
+  appendPlainSection(lines, 'Recent logs', input.logs)
 
   return `${lines.join('\n')}\n`
 }

--- a/src/runner-command.ts
+++ b/src/runner-command.ts
@@ -1,9 +1,21 @@
+const allowedRunnerCommands = new Set([
+  'bunx',
+  'npx',
+  'pnpm exec',
+  'yarn dlx',
+])
+
 export function formatRunnerCommand(runner: string, args: string[]): string {
   return `${runner} ${args.join(' ')}`
 }
 
 export function splitRunnerCommand(runner: string): { command: string, args: string[] } {
-  const parts = runner.split(' ').map(part => part.trim()).filter(Boolean)
+  const normalizedRunner = runner.trim().replaceAll(/\s+/g, ' ')
+  if (!allowedRunnerCommands.has(normalizedRunner)) {
+    throw new Error(`Unsupported package manager runner: "${runner}"`)
+  }
+
+  const parts = normalizedRunner.split(' ').map(part => part.trim()).filter(Boolean)
   const [command = runner, ...args] = parts
   return { command, args }
 }

--- a/src/runner-command.ts
+++ b/src/runner-command.ts
@@ -1,3 +1,5 @@
+const RUNNER_WHITESPACE_RE = /\s+/g
+
 const allowedRunnerCommands = new Set([
   'bunx',
   'npx',
@@ -10,7 +12,7 @@ export function formatRunnerCommand(runner: string, args: string[]): string {
 }
 
 export function splitRunnerCommand(runner: string): { command: string, args: string[] } {
-  const normalizedRunner = runner.trim().replaceAll(/\s+/g, ' ')
+  const normalizedRunner = runner.trim().replaceAll(RUNNER_WHITESPACE_RE, ' ')
   if (!allowedRunnerCommands.has(normalizedRunner)) {
     throw new Error(`Unsupported package manager runner: "${runner}"`)
   }

--- a/src/runner-command.ts
+++ b/src/runner-command.ts
@@ -1,0 +1,9 @@
+export function formatRunnerCommand(runner: string, args: string[]): string {
+  return `${runner} ${args.join(' ')}`
+}
+
+export function splitRunnerCommand(runner: string): { command: string, args: string[] } {
+  const parts = runner.split(' ').map(part => part.trim()).filter(Boolean)
+  const [command = runner, ...args] = parts
+  return { command, args }
+}

--- a/test/test-onboarding-recovery.mjs
+++ b/test/test-onboarding-recovery.mjs
@@ -75,26 +75,29 @@ t('support bundle writer persists a file', () => {
   const originalHome = process.env.HOME
   const home = mkdtempSync(join(tmpdir(), 'capgo-home-'))
   process.env.HOME = home
-  const filePath = writeOnboardingSupportBundle({
-    kind: 'build-init',
-    appId: 'com.example.app',
-    error: 'broken',
-  })
+  try {
+    const filePath = writeOnboardingSupportBundle({
+      kind: 'build-init',
+      appId: 'com.example.app',
+      error: 'broken',
+    })
 
-  if (!filePath)
-    throw new Error('Expected support bundle file path')
-  if (!existsSync(filePath))
-    throw new Error('Expected support bundle file to exist')
+    if (!filePath)
+      throw new Error('Expected support bundle file path')
+    if (!existsSync(filePath))
+      throw new Error('Expected support bundle file to exist')
 
-  const contents = readFileSync(filePath, 'utf8')
-  if (!contents.includes('Capgo build-init support bundle'))
-    throw new Error('Expected support bundle header in file')
-
-  rmSync(home, { recursive: true, force: true })
-  if (typeof originalHome === 'undefined')
-    delete process.env.HOME
-  else
-    process.env.HOME = originalHome
+    const contents = readFileSync(filePath, 'utf8')
+    if (!contents.includes('Capgo build-init support bundle'))
+      throw new Error('Expected support bundle header in file')
+  }
+  finally {
+    rmSync(home, { recursive: true, force: true })
+    if (originalHome === undefined)
+      delete process.env.HOME
+    else
+      process.env.HOME = originalHome
+  }
 })
 
 t('support bundle writer fails safely when the home path is not writable', () => {

--- a/test/test-onboarding-recovery.mjs
+++ b/test/test-onboarding-recovery.mjs
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import process from 'node:process'
 import { getBuildOnboardingRecoveryAdvice } from '../src/build/onboarding/recovery.ts'
 import { renderOnboardingSupportBundle, writeOnboardingSupportBundle } from '../src/onboarding-support.ts'
+import { splitRunnerCommand } from '../src/runner-command.ts'
 
 let failures = 0
 
@@ -33,6 +34,19 @@ t('build onboarding advice suggests login and build request after missing auth',
     throw new Error('Expected login command in recovery advice')
   if (!advice.commands.includes('bunx @capgo/cli@latest build request com.example.app --platform ios'))
     throw new Error('Expected build request command in recovery advice')
+})
+
+t('runner command helper rejects unexpected executors', () => {
+  let threw = false
+  try {
+    splitRunnerCommand('sh -c')
+  }
+  catch {
+    threw = true
+  }
+
+  if (!threw)
+    throw new Error('Expected unsupported runner to throw')
 })
 
 t('support bundle renderer includes commands and docs', () => {

--- a/test/test-onboarding-recovery.mjs
+++ b/test/test-onboarding-recovery.mjs
@@ -1,0 +1,84 @@
+import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import process from 'node:process'
+import { getBuildOnboardingRecoveryAdvice } from '../src/build/onboarding/recovery.ts'
+import { renderOnboardingSupportBundle, writeOnboardingSupportBundle } from '../src/onboarding-support.ts'
+
+let failures = 0
+
+function t(name, fn) {
+  try {
+    fn()
+    console.log(`✓ ${name}`)
+  }
+  catch (error) {
+    failures += 1
+    console.error(`❌ ${name}`)
+    console.error(error)
+  }
+}
+
+t('build onboarding advice suggests platform creation commands', () => {
+  const advice = getBuildOnboardingRecoveryAdvice('No ios/ directory found.', 'no-platform', 'bunx', 'com.example.app')
+  if (!advice.commands.includes('bunx cap add ios'))
+    throw new Error('Expected bunx cap add ios command in recovery advice')
+  if (!advice.commands.includes('bunx cap sync ios'))
+    throw new Error('Expected bunx cap sync ios command in recovery advice')
+})
+
+t('build onboarding advice suggests login and build request after missing auth', () => {
+  const advice = getBuildOnboardingRecoveryAdvice('No Capgo API key found.', 'requesting-build', 'bunx', 'com.example.app')
+  if (!advice.commands.includes('bunx @capgo/cli@latest login'))
+    throw new Error('Expected login command in recovery advice')
+  if (!advice.commands.includes('bunx @capgo/cli@latest build request com.example.app --platform ios'))
+    throw new Error('Expected build request command in recovery advice')
+})
+
+t('support bundle renderer includes commands and docs', () => {
+  const output = renderOnboardingSupportBundle({
+    kind: 'init',
+    appId: 'com.example.app',
+    currentStep: 'Step 4/12 · Add Integration Code',
+    packageManager: 'bun',
+    cwd: '/tmp/example',
+    error: 'Something failed',
+    commands: ['bunx @capgo/cli@latest doctor'],
+    docs: ['https://capgo.app/docs/getting-started/onboarding/'],
+    sections: [{ title: 'Context', lines: ['line one'] }],
+    logs: ['log one'],
+  })
+
+  if (!output.includes('bunx @capgo/cli@latest doctor'))
+    throw new Error('Expected command in support bundle output')
+  if (!output.includes('https://capgo.app/docs/getting-started/onboarding/'))
+    throw new Error('Expected docs URL in support bundle output')
+  if (!output.includes('Current step: Step 4/12 · Add Integration Code'))
+    throw new Error('Expected current step in support bundle output')
+})
+
+t('support bundle writer persists a file', () => {
+  const home = join(tmpdir(), `capgo-home-${Date.now()}`)
+  process.env.HOME = home
+  const filePath = writeOnboardingSupportBundle({
+    kind: 'build-init',
+    appId: 'com.example.app',
+    error: 'broken',
+  })
+
+  if (!existsSync(filePath))
+    throw new Error('Expected support bundle file to exist')
+
+  const contents = readFileSync(filePath, 'utf8')
+  if (!contents.includes('Capgo build-init support bundle'))
+    throw new Error('Expected support bundle header in file')
+
+  rmSync(home, { recursive: true, force: true })
+})
+
+if (failures > 0) {
+  console.error(`\n❌ ${failures} onboarding recovery test(s) failed`)
+  process.exit(1)
+}
+
+console.log('\n✅ onboarding recovery tests passed')

--- a/test/test-onboarding-recovery.mjs
+++ b/test/test-onboarding-recovery.mjs
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import process from 'node:process'
@@ -72,6 +72,7 @@ t('support bundle renderer includes commands and docs', () => {
 })
 
 t('support bundle writer persists a file', () => {
+  const originalHome = process.env.HOME
   const home = join(tmpdir(), `capgo-home-${Date.now()}`)
   process.env.HOME = home
   const filePath = writeOnboardingSupportBundle({
@@ -80,6 +81,8 @@ t('support bundle writer persists a file', () => {
     error: 'broken',
   })
 
+  if (!filePath)
+    throw new Error('Expected support bundle file path')
   if (!existsSync(filePath))
     throw new Error('Expected support bundle file to exist')
 
@@ -88,6 +91,26 @@ t('support bundle writer persists a file', () => {
     throw new Error('Expected support bundle header in file')
 
   rmSync(home, { recursive: true, force: true })
+  if (typeof originalHome === 'undefined')
+    delete process.env.HOME
+  else
+    process.env.HOME = originalHome
+})
+
+t('support bundle writer fails safely when the home path is not writable', () => {
+  const blockedPath = join(tmpdir(), `capgo-support-blocked-${Date.now()}`)
+  writeFileSync(blockedPath, 'not-a-directory', 'utf8')
+
+  const filePath = writeOnboardingSupportBundle({
+    kind: 'init',
+    appId: 'com.example.app',
+    error: 'broken',
+  }, blockedPath)
+
+  if (filePath !== null)
+    throw new Error('Expected support bundle writer to fail safely')
+
+  rmSync(blockedPath, { force: true })
 })
 
 if (failures > 0) {

--- a/test/test-onboarding-recovery.mjs
+++ b/test/test-onboarding-recovery.mjs
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import process from 'node:process'
@@ -55,7 +55,7 @@ t('support bundle renderer includes commands and docs', () => {
     appId: 'com.example.app',
     currentStep: 'Step 4/12 · Add Integration Code',
     packageManager: 'bun',
-    cwd: '/tmp/example',
+    cwd: '/Users/example/project',
     error: 'Something failed',
     commands: ['bunx @capgo/cli@latest doctor'],
     docs: ['https://capgo.app/docs/getting-started/onboarding/'],
@@ -73,7 +73,7 @@ t('support bundle renderer includes commands and docs', () => {
 
 t('support bundle writer persists a file', () => {
   const originalHome = process.env.HOME
-  const home = join(tmpdir(), `capgo-home-${Date.now()}`)
+  const home = mkdtempSync(join(tmpdir(), 'capgo-home-'))
   process.env.HOME = home
   const filePath = writeOnboardingSupportBundle({
     kind: 'build-init',
@@ -98,7 +98,8 @@ t('support bundle writer persists a file', () => {
 })
 
 t('support bundle writer fails safely when the home path is not writable', () => {
-  const blockedPath = join(tmpdir(), `capgo-support-blocked-${Date.now()}`)
+  const blockedDir = mkdtempSync(join(tmpdir(), 'capgo-support-blocked-'))
+  const blockedPath = join(blockedDir, 'not-a-directory')
   writeFileSync(blockedPath, 'not-a-directory', 'utf8')
 
   const filePath = writeOnboardingSupportBundle({
@@ -110,7 +111,7 @@ t('support bundle writer fails safely when the home path is not writable', () =>
   if (filePath !== null)
     throw new Error('Expected support bundle writer to fail safely')
 
-  rmSync(blockedPath, { force: true })
+  rmSync(blockedDir, { recursive: true, force: true })
 })
 
 if (failures > 0) {

--- a/webdocs/build.mdx
+++ b/webdocs/build.mdx
@@ -13,7 +13,7 @@ sidebar:
 **Alias:** `onboarding`
 
 ```bash
-bunx @capgo/cli@latest build init
+npx @capgo/cli@latest build init
 ```
 
 Set up iOS build credentials interactively (creates certificates and profiles automatically)
@@ -22,7 +22,7 @@ If `ios/` is missing, the onboarding can offer to run `cap add ios` for you. Une
 ### <a id="build-request"></a> 🔹 **Request**
 
 ```bash
-bunx @capgo/cli@latest build request
+npx @capgo/cli@latest build request
 ```
 
 Request a native build from Capgo Cloud.
@@ -31,12 +31,12 @@ The build will be processed and sent directly to app stores.
  🔒 SECURITY: Credentials are never stored on Capgo servers. They are auto-deleted
     after build completion. Build outputs may optionally be uploaded for time-limited download links.
 📋 PREREQUISITE: Save credentials first with:
-   `bunx @capgo/cli build credentials save --appId <app-id> --platform <ios|android>`
+   `npx @capgo/cli build credentials save --appId <app-id> --platform <ios|android>`
 
 **Example:**
 
 ```bash
-bunx @capgo/cli@latest build request com.example.app --platform ios --path .
+npx @capgo/cli@latest build request com.example.app --platform ios --path .
 ```
 
 **Options:**
@@ -78,7 +78,7 @@ bunx @capgo/cli@latest build request com.example.app --platform ios --path .
 ### <a id="build-credentials"></a> 🔹 **Credentials**
 
 ```bash
-bunx @capgo/cli@latest build credentials
+npx @capgo/cli@latest build credentials
 ```
 
 Manage build credentials stored locally on your machine.

--- a/webdocs/build.mdx
+++ b/webdocs/build.mdx
@@ -13,15 +13,16 @@ sidebar:
 **Alias:** `onboarding`
 
 ```bash
-npx @capgo/cli@latest build init
+bunx @capgo/cli@latest build init
 ```
 
 Set up iOS build credentials interactively (creates certificates and profiles automatically)
+If `ios/` is missing, the onboarding can offer to run `cap add ios` for you. Unexpected failures stay inside the recovery UI, show package-manager-aware next commands, and save a support bundle under `~/.capgo-credentials/support/`.
 
 ### <a id="build-request"></a> 🔹 **Request**
 
 ```bash
-npx @capgo/cli@latest build request
+bunx @capgo/cli@latest build request
 ```
 
 Request a native build from Capgo Cloud.
@@ -30,12 +31,12 @@ The build will be processed and sent directly to app stores.
  🔒 SECURITY: Credentials are never stored on Capgo servers. They are auto-deleted
     after build completion. Build outputs may optionally be uploaded for time-limited download links.
 📋 PREREQUISITE: Save credentials first with:
-   `npx @capgo/cli build credentials save --appId <app-id> --platform <ios|android>`
+   `bunx @capgo/cli build credentials save --appId <app-id> --platform <ios|android>`
 
 **Example:**
 
 ```bash
-npx @capgo/cli@latest build request com.example.app --platform ios --path .
+bunx @capgo/cli@latest build request com.example.app --platform ios --path .
 ```
 
 **Options:**
@@ -77,7 +78,7 @@ npx @capgo/cli@latest build request com.example.app --platform ios --path .
 ### <a id="build-credentials"></a> 🔹 **Credentials**
 
 ```bash
-npx @capgo/cli@latest build credentials
+bunx @capgo/cli@latest build credentials
 ```
 
 Manage build credentials stored locally on your machine.
@@ -89,4 +90,3 @@ Manage build credentials stored locally on your machine.
 📚 DOCUMENTATION:
    iOS setup: https://capgo.app/docs/cli/cloud-build/ios/
    Android setup: https://capgo.app/docs/cli/cloud-build/android/
-

--- a/webdocs/init.mdx
+++ b/webdocs/init.mdx
@@ -11,16 +11,17 @@ sidebar:
 **Alias:** `i`
 
 ```bash
-npx @capgo/cli@latest init
+bunx @capgo/cli@latest init
 ```
 
 This includes adding code for updates, building, uploading your app, and verifying update functionality.
 Capgo bundles are web assets and can be fetched by anyone who knows the URL. Use encryption for banking, regulated, or other high-security apps.
+If onboarding hits a hard failure, the CLI now points to `doctor`, offers assisted recovery for missing native platforms, and saves a support bundle you can attach to a support request.
 
 **Example:**
 
 ```bash
-npx @capgo/cli@latest init YOUR_API_KEY com.example.app
+bunx @capgo/cli@latest init YOUR_API_KEY com.example.app
 ```
 
 ## <a id="options"></a> Options
@@ -31,4 +32,3 @@ npx @capgo/cli@latest init YOUR_API_KEY com.example.app
 | **-i,** | <code>string</code> | App icon path for display in Capgo Cloud |
 | **--supa-host** | <code>string</code> | Custom Supabase host URL (for self-hosting or Capgo development) |
 | **--supa-anon** | <code>string</code> | Custom Supabase anon key (for self-hosting) |
-

--- a/webdocs/init.mdx
+++ b/webdocs/init.mdx
@@ -11,7 +11,7 @@ sidebar:
 **Alias:** `i`
 
 ```bash
-bunx @capgo/cli@latest init
+npx @capgo/cli@latest init
 ```
 
 This includes adding code for updates, building, uploading your app, and verifying update functionality.
@@ -21,7 +21,7 @@ If onboarding hits a hard failure, the CLI now points to `doctor`, offers assist
 **Example:**
 
 ```bash
-bunx @capgo/cli@latest init YOUR_API_KEY com.example.app
+npx @capgo/cli@latest init YOUR_API_KEY com.example.app
 ```
 
 ## <a id="options"></a> Options


### PR DESCRIPTION
## Summary

- add shared onboarding support-bundle and runner-command helpers
- keep `init` and `build init` inside guided recovery flows with doctor/support options and package-manager-aware commands
- auto-offer native platform creation when onboarding detects missing `ios/` or `android/` folders
- add regression coverage for onboarding recovery helpers and update related skills/webdocs

## Why

The onboarding flows still had several branches that dropped users into manual remediation with weak guidance or hard exits. This patch keeps them in the loop longer, offers concrete next actions, and leaves a support artifact behind when recovery still fails.

## Validation

- `bun install --frozen-lockfile`
- `bun run lint`
- `bun run build`
- `./test/fixtures/setup-test-projects.sh`
- `bun run test`
- `node dist/index.js --help`
- `node dist/index.js --version`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onboarding shows tailored recovery guidance with runner-aware suggested commands and docs.
  * Onboarding can automatically add missing native platforms and re-check.
  * Generates onboarding/init support bundles for troubleshooting and improved restart behavior.
  * Init flow includes enhanced diagnostics and recovery actions (doctor, support bundle).

* **Documentation**
  * CLI examples standardized to repository-appropriate runners; docs describe recovery flows and support-bundle usage.

* **Tests**
  * Added end-to-end tests for onboarding recovery advice and support-bundle generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->