### PR TITLE
feat(build init): add -a/--apikey option for non-interactive auth

### DIFF
--- a/skills/native-builds/SKILL.md
+++ b/skills/native-builds/SKILL.md
@@ -15,6 +15,9 @@ Use this skill for Capgo Cloud native iOS and Android build workflows.
 - Reduces iOS setup from ~10 manual steps to 1 manual step (creating an API key) + 1 command.
 - Example: `npx @capgo/cli@latest build init`
 - Backward compatibility: `npx @capgo/cli@latest build onboarding` still works.
+- Options:
+  - `-a, --apikey <apikey>` — Capgo API key to authenticate with (alternative to the `CAPGO_TOKEN` env var or `~/.capgo` / local `.capgo` file). Takes precedence over a saved key when both are present. Lets the SaaS onboarding wizard render a single copy-pasteable command across bash, zsh, fish, PowerShell, and cmd.exe.
+  - Example: `npx @capgo/cli@latest build init -a cap_xxx`
 - Notes:
   - Uses Ink (React for terminal) for the interactive UI, alongside the main `init` onboarding flow.
   - Requires running inside a Capacitor project directory with an `ios/` folder.

--- a/src/build/onboarding/command.ts
+++ b/src/build/onboarding/command.ts
@@ -8,7 +8,11 @@ import { getPlatformDirFromCapacitorConfig } from '../platform-paths.js'
 import { loadProgress } from './progress.js'
 import OnboardingApp from './ui/app.js'
 
-export async function onboardingBuilderCommand(): Promise<void> {
+export interface OnboardingBuilderOptions {
+  apikey?: string
+}
+
+export async function onboardingBuilderCommand(options: OnboardingBuilderOptions = {}): Promise<void> {
   // Ink requires an interactive terminal — fail fast in CI/pipes
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
     console.error('Error: `build init` requires an interactive terminal.')
@@ -39,7 +43,7 @@ export async function onboardingBuilderCommand(): Promise<void> {
 
   // Launch Ink app
   const { waitUntilExit } = render(
-    React.createElement(OnboardingApp, { appId, initialProgress: progress, iosDir }),
+    React.createElement(OnboardingApp, { appId, initialProgress: progress, iosDir, apikey: options.apikey }),
   )
 
   await waitUntilExit()

--- a/src/build/onboarding/ui/app.tsx
+++ b/src/build/onboarding/ui/app.tsx
@@ -13,7 +13,7 @@ import { Box, Newline, Text, useApp, useInput, useStdout } from 'ink'
 import open from 'open'
 // src/build/onboarding/ui/app.tsx
 import React, { useCallback, useEffect, useRef, useState } from 'react'
-import { findSavedKey } from '../../../utils.js'
+import { findSavedKeySilent } from '../../../utils.js'
 import { loadSavedCredentials, updateSavedCredentials } from '../../credentials.js'
 import { requestBuildInternal } from '../../request.js'
 import { CertificateLimitError, createCertificate, createProfile, deleteProfile, DuplicateProfileError, ensureBundleId, generateJwt, revokeCertificate, verifyApiKey } from '../apple-api.js'
@@ -512,15 +512,7 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir, apikey })
     if (step === 'requesting-build') {
       ;(async () => {
         try {
-          let capgoKey: string | undefined = apikey
-          if (!capgoKey) {
-            try {
-              capgoKey = findSavedKey(true)
-            }
-            catch {
-              // No key found
-            }
-          }
+          const capgoKey = apikey ?? findSavedKeySilent()
           if (!capgoKey) {
             setBuildOutput(prev => [...prev, '⚠ No Capgo API key found.'])
             setBuildOutput(prev => [...prev, 'Run `capgo login` first, then `capgo build request`.'])

--- a/src/build/onboarding/ui/app.tsx
+++ b/src/build/onboarding/ui/app.tsx
@@ -34,9 +34,11 @@ interface AppProps {
   initialProgress: OnboardingProgress | null
   /** Resolved iOS directory from capacitor.config (defaults to 'ios') */
   iosDir: string
+  /** Optional Capgo API key passed via -a/--apikey flag; takes precedence over saved key */
+  apikey?: string
 }
 
-const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir }) => {
+const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir, apikey }) => {
   const { exit } = useApp()
   const startStep = getResumeStep(initialProgress)
 
@@ -510,12 +512,14 @@ const OnboardingApp: FC<AppProps> = ({ appId, initialProgress, iosDir }) => {
     if (step === 'requesting-build') {
       ;(async () => {
         try {
-          let capgoKey: string | undefined
-          try {
-            capgoKey = findSavedKey(true)
-          }
-          catch {
-            // No key found
+          let capgoKey: string | undefined = apikey
+          if (!capgoKey) {
+            try {
+              capgoKey = findSavedKey(true)
+            }
+            catch {
+              // No key found
+            }
           }
           if (!capgoKey) {
             setBuildOutput(prev => [...prev, '⚠ No Capgo API key found.'])

--- a/src/index.ts
+++ b/src/index.ts
@@ -734,6 +734,7 @@ build
   .command('init')
   .alias('onboarding')
   .description('Set up iOS build credentials interactively (creates certificates and profiles automatically)')
+  .option('-a, --apikey <apikey>', 'API key to link to your account')
   .action(onboardingBuilderCommand)
 
 build

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -874,18 +874,27 @@ export async function checkPlanValidUpload(supabase: SupabaseClient<Database>, o
     log.warn(`WARNING !!\nTrial expires in ${trialDays} days, upgrade here: ${config.hostWeb}/settings/organization/plans\n`)
 }
 
+function tryReadKey(path: string): string | undefined {
+  try {
+    if (!existsSync(path))
+      return undefined
+    return readFileSync(path, 'utf8').trim() || undefined
+  }
+  catch {
+    // Swallow permission errors, TOCTOU races, transient fs issues —
+    // the contract is silent best-effort resolution.
+    return undefined
+  }
+}
+
 export function findSavedKeySilent(): string | undefined {
   const envKey = env.CAPGO_TOKEN?.trim()
   if (envKey)
     return envKey
-  const userHomeDir = homedir()
-  const globalPath = `${userHomeDir}/.capgo`
-  if (existsSync(globalPath))
-    return readFileSync(globalPath, 'utf8').trim() || undefined
-  const localPath = `.capgo`
-  if (existsSync(localPath))
-    return readFileSync(localPath, 'utf8').trim() || undefined
-  return undefined
+  const globalKey = tryReadKey(`${homedir()}/.capgo`)
+  if (globalKey)
+    return globalKey
+  return tryReadKey(`.capgo`)
 }
 
 export function findSavedKey(quiet = false) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -874,6 +874,20 @@ export async function checkPlanValidUpload(supabase: SupabaseClient<Database>, o
     log.warn(`WARNING !!\nTrial expires in ${trialDays} days, upgrade here: ${config.hostWeb}/settings/organization/plans\n`)
 }
 
+export function findSavedKeySilent(): string | undefined {
+  const envKey = env.CAPGO_TOKEN?.trim()
+  if (envKey)
+    return envKey
+  const userHomeDir = homedir()
+  const globalPath = `${userHomeDir}/.capgo`
+  if (existsSync(globalPath))
+    return readFileSync(globalPath, 'utf8').trim() || undefined
+  const localPath = `.capgo`
+  if (existsSync(localPath))
+    return readFileSync(localPath, 'utf8').trim() || undefined
+  return undefined
+}
+
 export function findSavedKey(quiet = false) {
   const envKey = env.CAPGO_TOKEN?.trim()
   if (envKey) {

--- a/webdocs/build.mdx
+++ b/webdocs/build.mdx
@@ -18,6 +18,12 @@ npx @capgo/cli@latest build init
 
 Set up iOS build credentials interactively (creates certificates and profiles automatically)
 
+**Options:**
+
+| Param         | Type          | Description          |
+| ------------- | ------------- | -------------------- |
+| **--apikey** | <code>string</code> | API key to link to your account (alternative to `CAPGO_TOKEN` env var or saved `.capgo` key) |
+
 ### <a id="build-request"></a> 🔹 **Request**
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds `-a, --apikey <apikey>` option to `build init` (alias `onboarding`), matching every other `build` subcommand.
- Threads the option through `onboardingBuilderCommand` → `OnboardingApp` → the build-request step, where it takes precedence over `findSavedKey()`.
- Lets the Capgo SaaS onboarding wizard render a single copy-pasteable command (`npx @capgo/cli@latest build init -a cap_xxx`) instead of the clunky `CAPGO_TOKEN=...` env-var prefix, which also fixes Windows cmd.exe incompatibility.

Closes #587

## Test plan

- [ ] `npx @capgo/cli build init -a cap_xxx` in a Capacitor project runs the interactive onboarding flow
- [ ] After credential save, the final build request authenticates using the inline apikey (no `~/.capgo` / `CAPGO_TOKEN` needed)
- [ ] `npx @capgo/cli build init` (no flag) still falls back to `findSavedKey()` — no regression
- [ ] `npx @capgo/cli build init --help` shows the new `-a, --apikey` option

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--apikey` (`-a`) option to the build init/onboarding command so users can supply API credentials inline.
  * CLI-supplied credentials now take priority over any saved account key; onboarding will use the provided key when present.
  * Onboarding now performs a quieter background lookup for a saved API key, reducing noisy errors when none is found.

* **Documentation**
  * Command docs and examples updated to include the new `--apikey` option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->