### PR TITLE
[codex] add repository deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+> [!WARNING]
+> # This repository is deprecated
+>
+> The Capgo CLI now lives in the main [Capgo monorepo](https://github.com/Cap-go/capgo).
+> This repository will be archived. Please open new issues, pull requests, and CLI development work in the Capgo monorepo instead.
+>
+> For current CLI documentation, use the [Capgo CLI docs](https://capgo.app/docs/cli/overview/).
+
 # Capgo CLI
   <a href="https://capgo.app/"><img src='https://raw.githubusercontent.com/Cap-go/capgo/main/assets/capgo_banner.png' alt='Capgo - Instant updates for capacitor'/></a>
 


### PR DESCRIPTION
## Summary

- Add a prominent GitHub warning at the top of the README stating that this repository is deprecated.
- Point users to the main Capgo monorepo where the CLI now lives.
- Link to the current Capgo CLI documentation.

## Impact

Users landing on this repository will immediately see that new issues, pull requests, and CLI development should happen in the Capgo monorepo instead.

## Validation

- README diff reviewed locally.
- CI checks pending on this draft PR.